### PR TITLE
Fix preact/debug not injected on windows

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -2,6 +2,7 @@ import { Plugin, ResolvedConfig } from "vite";
 import path from "path";
 import debug from "debug";
 import * as kl from "kolorist";
+import { toRollupPath } from "./utils";
 
 export interface PreactDevtoolsPluginOptions {
 	injectInProd?: boolean;
@@ -34,7 +35,8 @@ export function preactDevtoolsPlugin({
 				/\.[tj]sx?$/.test(id)
 			) {
 				found = true;
-				entry = path.join(config.root, id);
+
+				entry = toRollupPath(path.join(config.root, id));
 
 				// TODO: Vite types require explicit return
 				// undefined here. They're lacking the "void" type

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+import path from "path";
+
+/**
+ * Normalize paths to match rollup's path normalization. All path separators
+ * are converted to posix and duplicate seperators are merged.
+ * Example:
+ *   C:\\temp\\\\foo\\bar\\..\\ -> C:/temp/foo/bar
+ */
+export function toRollupPath(fileName: string) {
+	return path.normalize(fileName).split(path.sep).join(path.posix.sep);
+}


### PR DESCRIPTION
This issue was caused by differences in path handling on windows. Rollup internally normalizes all paths to only have posix path separators `/` everywhere and merges subsequent seperators into one.

Due to that mismatch the entry path never matched rollup's id path leading to `preact/debug` to never be injected.

Fixes #6