### PR TITLE
Do not return code from transform when not transforming

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -50,9 +50,10 @@ export function preactDevtoolsPlugin({
 				code = `import "${source}";\n${code}`;
 
 				log(`[inject] ${kl.cyan(source)} -> ${kl.dim(id)}`);
+				return code;
 			}
 
-			return code;
+			return undefined;
 		},
 	};
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -53,7 +53,6 @@ export function preactDevtoolsPlugin({
 				return code;
 			}
 
-			return;
 		},
 	};
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -53,7 +53,7 @@ export function preactDevtoolsPlugin({
 				return code;
 			}
 
-			return undefined;
+			return;
 		},
 	};
 


### PR DESCRIPTION
When building with the sourcemap option config enabled (`vite build --sourcemap`), this message comes up:

```
Sourcemap is likely to be incorrect: a plugin (preact:devtools) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

This is because rollup [transform hook](https://rollupjs.org/guide/en/#transformers) should not return an object when doesn't apply any transforms