### PR TITLE
Optionally disable jsxInject by the configuration option  disableJsxInject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IntelliJ IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ export default defineConfig({
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
+| `disableJsxInject` | `boolean` | `false` | Disable automatic imports for JSX in Preact |
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,37 @@ import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools";
 import { hookNamesPlugin } from "./hook-names";
 
+export interface ESBuildConfig {
+	jsxFactory: string;
+	jsxFragment: string;
+	jsxInject?: string;
+}
+
 export interface PreactPluginOptions {
 	devtoolsInProd?: boolean;
+	disableJsxInject?: boolean;
 }
 
 export default function preactPlugin({
 	devtoolsInProd,
+	disableJsxInject,
 }: PreactPluginOptions = {}): Plugin[] {
+	const esBuildConfig: ESBuildConfig = {
+		jsxFactory: "h",
+		jsxFragment: "Fragment",
+		...(!disableJsxInject
+			? {
+					jsxInject: `import { h, Fragment } from 'preact'`,
+			  }
+			: {}),
+	};
+
 	return [
 		{
 			name: "preact:config",
 			config() {
 				return {
-					esbuild: {
-						jsxFactory: "h",
-						jsxFragment: "Fragment",
-						jsxInject: `import { h, Fragment } from 'preact'`,
-					},
+					esbuild: esBuildConfig,
 					resolve: {
 						alias: {
 							"react-dom/test-utils": "preact/test-utils",


### PR DESCRIPTION
I am facing the same issue described [here](https://github.com/preactjs/preset-vite/issues/4) when I try to configure Unit tests in my project with Jest and ViteJS

This PR provides an option `disableJsxInject` to disable `jsxInject`.