### PR TITLE
Use isProduction to decide whether to enable development-only transforms

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -45,7 +45,7 @@ export function preactDevtoolsPlugin({
 		},
 
 		transform(code, id) {
-			if (entry === id && (config.command === "serve" || injectInProd)) {
+			if (entry === id && (!config.isProduction || injectInProd)) {
 				const source = injectInProd ? "preact/devtools" : "preact/debug";
 				code = `import "${source}";\n${code}`;
 

--- a/src/hook-names.ts
+++ b/src/hook-names.ts
@@ -10,7 +10,7 @@ export function hookNamesPlugin(): Plugin {
 			config = resolvedConfig;
 		},
 		async transform(code, id) {
-			if (config.command !== "serve") {
+			if (config.isProduction) {
 				return;
 			}
 


### PR DESCRIPTION
The `config.isProduction` seems like a more reliable way to detect whether the plugin should inject code that is only desirable during development. This way things like development builds can more easily be realized (although it is questionable how well this is supported by Vite itself). I also think it is simply a cleaner solution than comparing the subcommand used when running Vite.