### PR TITLE
Migrate to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
 	"name": "@preact/preset-vite",
 	"version": "2.1.0",
 	"description": "Preact preset for the vite bundler",
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
+	"type": "module",
+	"exports": "./dist/index.js",
 	"types": "dist/types/index.d.ts",
 	"scripts": {
 		"dev": "vite demo",
 		"dev:build": "vite build demo",
-		"build": "rimraf dist/ && tsc && tsc -p tsconfig.esm.json",
+		"build": "rimraf dist && tsc",
 		"prepublishOnly": "npm run build"
 	},
 	"keywords": [

--- a/src/hook-names.ts
+++ b/src/hook-names.ts
@@ -19,7 +19,7 @@ export function hookNamesPlugin(): Plugin {
 			}
 
 			const res = await transformAsync(code, {
-				plugins: [require.resolve("babel-plugin-transform-hook-names")],
+				plugins: ["babel-plugin-transform-hook-names"],
 				filename: id,
 				sourceMaps: true,
 			});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "vite";
 import prefresh from "@prefresh/vite";
-import { preactDevtoolsPlugin } from "./devtools";
-import { hookNamesPlugin } from "./hook-names";
+import { preactDevtoolsPlugin } from "./devtools.js";
+import { hookNamesPlugin } from "./hook-names.js";
 
 export interface PreactPluginOptions {
 	devtoolsInProd?: boolean;

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "ES2020",
-    "outDir": "dist/esm/",
-    "declaration": true,
-    "declarationDir": "dist/types/"
-  },
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,
-    "module": "CommonJS",
+    "module": "ESNext",
     "moduleResolution": "Node",
-    "outDir": "dist/cjs/"
+    "outDir": "dist"
   },
   "files": ["./src/index.ts"]
 }


### PR DESCRIPTION
Since Vite templates use ESM, there is no reason for this module to stay in
CommonJS, or to provide a CJS and ESM interface. This only complicates things.

Fixes: https://github.com/preactjs/preset-vite/issues/11.
Closes: https://github.com/preactjs/preset-vite/pull/12.

I also confirm that I tested with the template https://github.com/vitejs/vite/tree/main/packages/create-vite/template-preact, and it works fine.