### PR TITLE
feat: jsxInject override

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Options can be passed to our preset plugin via the first argument:
 ```js
 export default defineConfig({
   plugins: [
-    preact({ devtoolsInProd: true })
+    preact({ 
+      devtoolsInProd: true
+    })
   ]
 });
 ```
@@ -45,6 +47,7 @@ export default defineConfig({
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
+| `jsxInject` | `string` |  | (Advanced option) Overwrites the default esbuild `jsxInject` option. <br>To disable injection set `{ jsxInject: ''}`. This might be desired if `import { h } from 'preact'` needs to be part of all .jsx files. |
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,12 @@ import { hookNamesPlugin } from "./hook-names.js";
 
 export interface PreactPluginOptions {
 	devtoolsInProd?: boolean;
+	jsxInject?: string;
 }
 
 export default function preactPlugin({
 	devtoolsInProd,
+	jsxInject,
 }: PreactPluginOptions = {}): Plugin[] {
 	return [
 		{
@@ -18,7 +20,7 @@ export default function preactPlugin({
 					esbuild: {
 						jsxFactory: "h",
 						jsxFragment: "Fragment",
-						jsxInject: `import { h, Fragment } from 'preact'`,
+						jsxInject: jsxInject ?? `import { h, Fragment } from 'preact'`,
 					},
 					resolve: {
 						alias: {


### PR DESCRIPTION
Some tooling (outside vite/ esbuild) require the `import {h} from 'preact'` being explicitely set in code as the injection is not known to those.
This causes constant pain when needing to switch same jsx code to a different bundling tool.
In this change a `jsxInject` override plugin property is introduced to allow custom overriding of the jsxInject method.
Most probably you'd like to use it this way in your `vite.config.ts` file
```
import { defineConfig } from "vite";
import preact from "@preact/preset-vite";

// https://vitejs.dev/config/
export default defineConfig({
	plugins: [preact({ jsxInject: '' })],
});
```