### PR TITLE
add automatic-jsx-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,19 @@
 			"version": "2.1.3",
 			"license": "MIT",
 			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^7.14.9",
 				"@prefresh/vite": "^2.2.3",
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.3.1",
-				"kolorist": "^1.2.10"
+				"kolorist": "^1.2.10",
+				"resolve": "^1.20.0"
 			},
 			"devDependencies": {
-				"@babel/core": "^7.13.15",
+				"@babel/core": "^7.15.8",
 				"@types/babel__core": "^7.1.14",
 				"@types/debug": "^4.1.5",
 				"@types/node": "^14.14.33",
+				"@types/resolve": "^1.20.1",
 				"lint-staged": "^10.5.4",
 				"prettier": "^2.2.1",
 				"rimraf": "^3.0.2",
@@ -33,32 +36,38 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+			"integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
 			"dependencies": {
-				"@babel/highlight": "^7.12.13"
+				"@babel/highlight": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
-			"integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+			"integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-			"integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+			"integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.9",
-				"@babel/helper-compilation-targets": "^7.13.13",
-				"@babel/helper-module-transforms": "^7.13.14",
-				"@babel/helpers": "^7.13.10",
-				"@babel/parser": "^7.13.15",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.15",
-				"@babel/types": "^7.13.14",
+				"@babel/code-frame": "^7.15.8",
+				"@babel/generator": "^7.15.8",
+				"@babel/helper-compilation-targets": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.8",
+				"@babel/helpers": "^7.15.4",
+				"@babel/parser": "^7.15.8",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -83,13 +92,16 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.13.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+			"integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
 			"dependencies": {
-				"@babel/types": "^7.13.0",
+				"@babel/types": "^7.15.6",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/generator/node_modules/source-map": {
@@ -100,132 +112,204 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.13.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-			"integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+		"node_modules/@babel/helper-annotate-as-pure": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
 			"dependencies": {
-				"@babel/compat-data": "^7.13.12",
-				"@babel/helper-validator-option": "^7.12.17",
-				"browserslist": "^4.14.5",
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+			"integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+			"dependencies": {
+				"@babel/compat-data": "^7.15.0",
+				"@babel/helper-validator-option": "^7.14.5",
+				"browserslist": "^4.16.6",
 				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+			"integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.12.13",
-				"@babel/template": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/helper-get-function-arity": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+			"integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
 			"dependencies": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+			"integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+			"dependencies": {
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
-			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+			"integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
 			"dependencies": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
-			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
 			"dependencies": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.13.14",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
-			"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+			"integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.13.12",
-				"@babel/helper-replace-supers": "^7.13.12",
-				"@babel/helper-simple-access": "^7.13.12",
-				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.13",
-				"@babel/types": "^7.13.14"
+				"@babel/helper-module-imports": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-simple-access": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+			"integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
 			"dependencies": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+			"integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.13.12",
-				"@babel/helper-optimise-call-expression": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.12"
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
-			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+			"integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
 			"dependencies": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+			"integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
 			"dependencies": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-			"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+			"integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
 			"dependencies": {
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -285,9 +369,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-			"integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -295,39 +379,80 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/template": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/parser": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-jsx": "^7.14.5",
+				"@babel/types": "^7.14.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+			"integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+			"dependencies": {
+				"@babel/code-frame": "^7.14.5",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-			"integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+			"integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.9",
-				"@babel/helper-function-name": "^7.12.13",
-				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/parser": "^7.13.15",
-				"@babel/types": "^7.13.14",
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.13.14",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-			"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+			"version": "7.15.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+			"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
+				"@babel/helper-validator-identifier": "^7.14.9",
 				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@prefresh/babel-plugin": {
@@ -436,6 +561,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+			"dev": true
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
+			"integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
 			"dev": true
 		},
 		"node_modules/aggregate-error": {
@@ -551,15 +682,15 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-			"integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+			"integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001208",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.712",
+				"caniuse-lite": "^1.0.30001264",
+				"electron-to-chromium": "^1.3.857",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"node-releases": "^1.1.77",
+				"picocolors": "^0.2.1"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -588,9 +719,13 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001209",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
-			"integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA=="
+			"version": "1.0.30001265",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+			"integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.0",
@@ -662,11 +797,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"node_modules/colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
 		},
 		"node_modules/commander": {
 			"version": "6.2.1",
@@ -759,9 +889,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.717",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-			"integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ=="
+			"version": "1.3.866",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.866.tgz",
+			"integrity": "sha512-iYze6TpDXWxk+sfcpUUdTs6Pv/3kG45Pnjer2DxEeFw0N08bZeNLuz97s2lMgy8yObon48o0WHY2Bkg3xuAPOA=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -1197,11 +1327,6 @@
 				"enquirer": ">= 2.3.0 < 3"
 			}
 		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-		},
 		"node_modules/log-symbols": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -1336,9 +1461,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.71",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+			"version": "1.1.77",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+			"integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -1461,6 +1586,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.2.2",
@@ -1936,32 +2066,32 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+			"integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
 			"requires": {
-				"@babel/highlight": "^7.12.13"
+				"@babel/highlight": "^7.14.5"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
-			"integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+			"integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
 		},
 		"@babel/core": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-			"integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+			"integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.9",
-				"@babel/helper-compilation-targets": "^7.13.13",
-				"@babel/helper-module-transforms": "^7.13.14",
-				"@babel/helpers": "^7.13.10",
-				"@babel/parser": "^7.13.15",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.15",
-				"@babel/types": "^7.13.14",
+				"@babel/code-frame": "^7.15.8",
+				"@babel/generator": "^7.15.8",
+				"@babel/helper-compilation-targets": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.8",
+				"@babel/helpers": "^7.15.4",
+				"@babel/parser": "^7.15.8",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -1978,11 +2108,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.13.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+			"integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
 			"requires": {
-				"@babel/types": "^7.13.0",
+				"@babel/types": "^7.15.6",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -1994,127 +2124,148 @@
 				}
 			}
 		},
-		"@babel/helper-compilation-targets": {
-			"version": "7.13.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-			"integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
 			"requires": {
-				"@babel/compat-data": "^7.13.12",
-				"@babel/helper-validator-option": "^7.12.17",
-				"browserslist": "^4.14.5",
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+			"integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+			"requires": {
+				"@babel/compat-data": "^7.15.0",
+				"@babel/helper-validator-option": "^7.14.5",
+				"browserslist": "^4.16.6",
 				"semver": "^6.3.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+			"integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.12.13",
-				"@babel/template": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/helper-get-function-arity": "^7.15.4",
+				"@babel/template": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+			"integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
 			"requires": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+			"integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+			"requires": {
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
-			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+			"integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
 			"requires": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
-			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
 			"requires": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.13.14",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
-			"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+			"integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.13.12",
-				"@babel/helper-replace-supers": "^7.13.12",
-				"@babel/helper-simple-access": "^7.13.12",
-				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.13",
-				"@babel/types": "^7.13.14"
+				"@babel/helper-module-imports": "^7.15.4",
+				"@babel/helper-replace-supers": "^7.15.4",
+				"@babel/helper-simple-access": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.6"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
-			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+			"integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
 			"requires": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
 			}
 		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+		},
 		"@babel/helper-replace-supers": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+			"integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.13.12",
-				"@babel/helper-optimise-call-expression": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.12"
+				"@babel/helper-member-expression-to-functions": "^7.15.4",
+				"@babel/helper-optimise-call-expression": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
-			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+			"integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
 			"requires": {
-				"@babel/types": "^7.13.12"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
-			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+			"integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
 			"requires": {
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
 		},
 		"@babel/helpers": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-			"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+			"integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
 			"requires": {
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
+				"@babel/template": "^7.15.4",
+				"@babel/traverse": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -2166,42 +2317,62 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-			"integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ=="
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-jsx": "^7.14.5",
+				"@babel/types": "^7.14.9"
+			}
 		},
 		"@babel/template": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
-			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+			"integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/parser": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/code-frame": "^7.14.5",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.13.15",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-			"integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+			"version": "7.15.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+			"integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.9",
-				"@babel/helper-function-name": "^7.12.13",
-				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/parser": "^7.13.15",
-				"@babel/types": "^7.13.14",
+				"@babel/code-frame": "^7.14.5",
+				"@babel/generator": "^7.15.4",
+				"@babel/helper-function-name": "^7.15.4",
+				"@babel/helper-hoist-variables": "^7.15.4",
+				"@babel/helper-split-export-declaration": "^7.15.4",
+				"@babel/parser": "^7.15.4",
+				"@babel/types": "^7.15.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.13.14",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-			"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+			"version": "7.15.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+			"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
+				"@babel/helper-validator-identifier": "^7.14.9",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -2301,6 +2472,12 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/resolve": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
+			"integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
+			"dev": true
+		},
 		"aggregate-error": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2385,15 +2562,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-			"integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+			"integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001208",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.712",
+				"caniuse-lite": "^1.0.30001264",
+				"electron-to-chromium": "^1.3.857",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"node-releases": "^1.1.77",
+				"picocolors": "^0.2.1"
 			}
 		},
 		"buffer-from": {
@@ -2409,9 +2586,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001209",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
-			"integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA=="
+			"version": "1.0.30001265",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+			"integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
 		},
 		"chalk": {
 			"version": "4.1.0",
@@ -2462,11 +2639,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
-		},
-		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
 		},
 		"commander": {
 			"version": "6.2.1",
@@ -2539,9 +2711,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.717",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-			"integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ=="
+			"version": "1.3.866",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.866.tgz",
+			"integrity": "sha512-iYze6TpDXWxk+sfcpUUdTs6Pv/3kG45Pnjer2DxEeFw0N08bZeNLuz97s2lMgy8yObon48o0WHY2Bkg3xuAPOA=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -2864,11 +3036,6 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-		},
 		"log-symbols": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -2972,9 +3139,9 @@
 			"integrity": "sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw=="
 		},
 		"node-releases": {
-			"version": "1.1.71",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+			"version": "1.1.77",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+			"integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
 		},
 		"normalize-path": {
 			"version": "3.0.0",
@@ -3061,6 +3228,11 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
+		},
+		"picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
 		},
 		"picomatch": {
 			"version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -32,20 +32,23 @@
 		"dist/"
 	],
 	"dependencies": {
+		"@babel/plugin-transform-react-jsx": "^7.14.9",
 		"@prefresh/vite": "^2.2.3",
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.1",
-		"kolorist": "^1.2.10"
+		"kolorist": "^1.2.10",
+		"resolve": "^1.20.0"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
 		"vite": "2.x"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.13.15",
+		"@babel/core": "^7.15.8",
 		"@types/babel__core": "^7.1.14",
 		"@types/debug": "^4.1.5",
 		"@types/node": "^14.14.33",
+		"@types/resolve": "^1.20.1",
 		"lint-staged": "^10.5.4",
 		"prettier": "^2.2.1",
 		"rimraf": "^3.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,108 @@
 import { Plugin } from "vite";
+import resolve from "resolve";
 import prefresh from "@prefresh/vite";
+import * as babel from "@babel/core";
 import { preactDevtoolsPlugin } from "./devtools.js";
 import { hookNamesPlugin } from "./hook-names.js";
+import { ParserPlugin } from "@babel/parser";
 
 export interface PreactPluginOptions {
 	devtoolsInProd?: boolean;
 }
 
+// Taken from https://github.com/vitejs/vite/blob/main/packages/plugin-react/src/index.ts
 export default function preactPlugin({
 	devtoolsInProd,
 }: PreactPluginOptions = {}): Plugin[] {
+	let projectRoot: string = process.cwd();
+	const jsxPlugin: Plugin = {
+		name: "vite:preact-jsx",
+		enforce: "pre",
+		config() {
+			return {
+				optimizeDeps: {
+					include: ["preact/jsx-runtime"],
+				},
+			};
+		},
+		configResolved(config) {
+			projectRoot = config.root;
+		},
+		resolveId(id: string) {
+			return id === "preact/jsx-runtime" ? id : null;
+		},
+		load(id: string) {
+			if (id === "preact/jsx-runtime") {
+				const runtimePath = resolve.sync("preact/jsx-runtime", {
+					basedir: projectRoot,
+				});
+				const exports = ["jsx", "jsxs", "Fragment"];
+				return [
+					`import * as jsxRuntime from ${JSON.stringify(runtimePath)}`,
+					// We can't use `export * from` or else any callsite that uses
+					// this module will be compiled to `jsxRuntime.exports.jsx`
+					// instead of the more concise `jsx` alias.
+					...exports.map(name => `export const ${name} = jsxRuntime.${name}`),
+				].join("\n");
+			}
+		},
+		transform(code, id) {
+			if (/\.[tj]sx?$/.test(id) && !id.includes("node_modules")) {
+				const parserPlugins = [
+					"importMeta",
+					// This plugin is applied before esbuild transforms the code,
+					// so we need to enable some stage 3 syntax that is supported in
+					// TypeScript and some environments already.
+					"topLevelAwait",
+					"classProperties",
+					"classPrivateProperties",
+					"classPrivateMethods",
+					!id.endsWith(".ts") && "jsx",
+					/\.tsx?$/.test(id) && "typescript",
+				].filter(Boolean) as ParserPlugin[];
+
+				const result = babel.transformSync(code, {
+					babelrc: false,
+					configFile: false,
+					ast: true,
+					root: projectRoot,
+					filename: id,
+					parserOpts: {
+						sourceType: "module",
+						allowAwaitOutsideFunction: true,
+						plugins: parserPlugins,
+					},
+					generatorOpts: {
+						decoratorsBeforeExport: true,
+					},
+					plugins: [
+						[
+							"@babel/plugin-transform-react-jsx",
+							{
+								runtime: "automatic",
+								importSource: "preact",
+							},
+						],
+					],
+					sourceMaps: true,
+					inputSourceMap: false as any,
+				});
+
+				if (!result) return { code };
+
+				return {
+					code: result.code || code,
+					map: result.map,
+				};
+			}
+			return undefined;
+		},
+	};
 	return [
 		{
 			name: "preact:config",
 			config() {
 				return {
-					esbuild: {
-						jsxFactory: "h",
-						jsxFragment: "Fragment",
-						jsxInject: `import { h, Fragment } from 'preact'`,
-					},
 					resolve: {
 						alias: {
 							"react-dom/test-utils": "preact/test-utils",
@@ -30,6 +113,7 @@ export default function preactPlugin({
 				};
 			},
 		},
+		jsxPlugin,
 		preactDevtoolsPlugin({ injectInProd: devtoolsInProd }),
 		prefresh(),
 		hookNamesPlugin(),


### PR DESCRIPTION
Potential follow ups:

- Combine Prefresh-transform in here for the optimal babel traverse
- Use `restore-jsx` https://github.com/vitejs/vite/blob/main/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.ts to rewrite jsx in node_modules