### PR TITLE
fix: avoid processing virtual modules in Vue single-file components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,10 @@ export default function preactPlugin({
 				].join("\n");
 			}
 		},
-		transform(code, id) {
+		transform(code, url) {
+			// Ignore query parameters, as in Vue SFC virtual modules.
+			const id = url.split('?', 2)[0]
+
 			if (/\.[tj]sx?$/.test(id) && !id.includes("node_modules")) {
 				const parserPlugins = [
 					"importMeta",


### PR DESCRIPTION
### Description 📖 

This pull request modifies the plugin `transform` function to avoid transforming virtual modules, such as those used by Vue single-file components.

Previously, the check is performed without removing a query string in the module `id`, which can lead to problems in Vite.js projects that also process Vue files.

<details>
<summary>Error Trace</summary>

```
[plugin:vite:preact-jsx] docs/src/components/SearchButton.vue?vue&type=scriptClient&index=0&client%3Aload=true&lang.ts:

Unexpected token, expected "," (1:8)

<script lang="ts" client:load>
        ^
```
</details>

### Screenshots 📷 

<img width="911" alt="Screen Shot 2021-10-18 at 14 41 45" src="https://user-images.githubusercontent.com/1158253/137780887-fcfb96f8-6fd3-4d61-9f34-a58e2884ef7a.png">
