### PR TITLE
feat: add include and exclude options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.14.9",
 				"@prefresh/vite": "^2.2.3",
+				"@rollup/pluginutils": "^4.1.1",
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.3.1",
 				"kolorist": "^1.2.10",
@@ -20,6 +21,7 @@
 				"@babel/core": "^7.15.8",
 				"@types/babel__core": "^7.1.14",
 				"@types/debug": "^4.1.5",
+				"@types/estree": "^0.0.50",
 				"@types/node": "^14.14.33",
 				"@types/resolve": "^1.20.1",
 				"lint-staged": "^10.5.4",
@@ -490,18 +492,15 @@
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-			"integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+			"integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
 			"dependencies": {
 				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
 			},
 			"engines": {
 				"node": ">= 8.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -549,6 +548,12 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+			"dev": true
+		},
+		"node_modules/@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -2632,9 +2637,9 @@
 			}
 		},
 		"@rollup/pluginutils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-			"integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+			"integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
 			"requires": {
 				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
@@ -2685,6 +2690,12 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+			"dev": true
+		},
+		"@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
 		"@types/node": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@babel/plugin-transform-react-jsx": "^7.14.9",
 		"@prefresh/vite": "^2.2.3",
+		"@rollup/pluginutils": "^4.1.1",
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.1",
 		"kolorist": "^1.2.10",
@@ -47,6 +48,7 @@
 		"@babel/core": "^7.15.8",
 		"@types/babel__core": "^7.1.14",
 		"@types/debug": "^4.1.5",
+		"@types/estree": "^0.0.50",
 		"@types/node": "^14.14.33",
 		"@types/resolve": "^1.20.1",
 		"lint-staged": "^10.5.4",


### PR DESCRIPTION
### Description 📖 

This pull request adds `include` and `exclude` options to the plugin to have more control over which files are transformed by Preact.

For backwards compatibility the behavior is preserved, and `.js` and `.ts` are still processed.

#### Motivation

Babel transforms are expensive, so for larger projects it's preferable to apply the transform only to `.tsx` files.

With this feature, a user can now provide:

```ts
import { defineConfig } from 'vite'
import preact from '@preact/preset-vite'

export default defineConfig({
  plugins: [
    preact({
      include: /\.[tj]sx$/,
    }),
  ],
})
```

and transform only files that will contain JSX.