### PR TITLE
fix: use .js extension when importing utils

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -3,8 +3,8 @@ import path from "path";
 import debug from "debug";
 import * as kl from "kolorist";
 
-import type { RollupFilter } from "./utils";
-import { parseId } from "./utils";
+import type { RollupFilter } from "./utils.js";
+import { parseId } from "./utils.js";
 
 export interface PreactDevtoolsPluginOptions {
 	injectInProd?: boolean;

--- a/src/hook-names.ts
+++ b/src/hook-names.ts
@@ -1,7 +1,7 @@
 import { transformAsync } from "@babel/core";
 import { Plugin, ResolvedConfig } from "vite";
-import type { RollupFilter } from "./utils";
-import { parseId } from "./utils";
+import type { RollupFilter } from "./utils.js";
+import { parseId } from "./utils.js";
 
 export interface PreactHookNamesPluginOptions {
 	shouldTransform: RollupFilter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import resolve from "resolve";
 import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools.js";
 import { hookNamesPlugin } from "./hook-names.js";
-import { createFilter, parseId } from "./utils";
+import { createFilter, parseId } from "./utils.js";
 import { transformAsync } from "@babel/core";
 
 export interface PreactPluginOptions {


### PR DESCRIPTION
I made this fix locally for the ESM build, thought I'd pass it on. The script in the `tools` directory isn't updating the `utils` import properly unless the `.js` extension is present.