### PR TITLE
Pass include/exclude to prefresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.14.9",
-				"@prefresh/vite": "^2.2.3",
+				"@prefresh/vite": "^2.2.4",
 				"@rollup/pluginutils": "^4.1.1",
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.3.1",
@@ -476,9 +476,9 @@
 			"integrity": "sha512-MUhT5m2XNN5NsZl4GnpuvlzLo6VSTa/+wBfBd3fiWUvHGhv0GF9hnA1pd//v0uJaKwUnVRQ1hYElxCV7DtYsCQ=="
 		},
 		"node_modules/@prefresh/vite": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.2.3.tgz",
-			"integrity": "sha512-TlAzVRKAZ3kiUryLzCd3AoqZDK6K7qZDc7C3QPI7hNwDGyZmJaHY+SXNMCCDaBW5xn9YlYqz/5bl3P4tptAcOg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.2.4.tgz",
+			"integrity": "sha512-rBBb3tagdigz2ukSc5Rtg8PrbmdvEtJhE37FJRQdHISMcVdN1OkL4003eH2DEOA1231ydbGiKqpaKZisI+zSEg==",
 			"dependencies": {
 				"@babel/core": "^7.9.6",
 				"@prefresh/babel-plugin": "0.4.1",
@@ -2625,9 +2625,9 @@
 			"integrity": "sha512-MUhT5m2XNN5NsZl4GnpuvlzLo6VSTa/+wBfBd3fiWUvHGhv0GF9hnA1pd//v0uJaKwUnVRQ1hYElxCV7DtYsCQ=="
 		},
 		"@prefresh/vite": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.2.3.tgz",
-			"integrity": "sha512-TlAzVRKAZ3kiUryLzCd3AoqZDK6K7qZDc7C3QPI7hNwDGyZmJaHY+SXNMCCDaBW5xn9YlYqz/5bl3P4tptAcOg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.2.4.tgz",
+			"integrity": "sha512-rBBb3tagdigz2ukSc5Rtg8PrbmdvEtJhE37FJRQdHISMcVdN1OkL4003eH2DEOA1231ydbGiKqpaKZisI+zSEg==",
 			"requires": {
 				"@babel/core": "^7.9.6",
 				"@prefresh/babel-plugin": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	],
 	"dependencies": {
 		"@babel/plugin-transform-react-jsx": "^7.14.9",
-		"@prefresh/vite": "^2.2.3",
+		"@prefresh/vite": "^2.2.4",
 		"@rollup/pluginutils": "^4.1.1",
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export default function preactPlugin({
 		},
 		jsxPlugin,
 		preactDevtoolsPlugin({ injectInProd: devtoolsInProd, shouldTransform }),
-		prefresh(),
+		prefresh({ include, exclude }),
 		hookNamesPlugin({ shouldTransform }),
 	];
 }


### PR DESCRIPTION
Since prefresh injects references to DOM nodes, its important to be able to exclude it from running on web worker scripts. This change passes the existing include/exclude options to `@prefresh/vite`.