### PR TITLE
Use JSX dev runtime for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.14.9",
+				"@babel/plugin-transform-react-jsx-development": "^7.16.7",
 				"@prefresh/vite": "^2.2.6",
 				"@rollup/pluginutils": "^4.1.1",
 				"babel-plugin-transform-hook-names": "^1.0.2",
@@ -115,11 +116,11 @@
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+			"integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
 			"dependencies": {
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.16.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -189,11 +190,11 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
 			"dependencies": {
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.16.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -229,9 +230,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -273,9 +274,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -382,11 +383,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+			"integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.16.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -396,15 +397,29 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+			"integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/plugin-syntax-jsx": "^7.14.5",
-				"@babel/types": "^7.14.9"
+				"@babel/helper-annotate-as-pure": "^7.16.7",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/helper-plugin-utils": "^7.16.7",
+				"@babel/plugin-syntax-jsx": "^7.16.7",
+				"@babel/types": "^7.17.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
+			"integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^7.16.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -446,11 +461,11 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-			"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+			"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -2357,11 +2372,11 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
-			"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+			"integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
 			"requires": {
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-compilation-targets": {
@@ -2410,11 +2425,11 @@
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-			"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
 			"requires": {
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-module-transforms": {
@@ -2441,9 +2456,9 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
 		},
 		"@babel/helper-replace-supers": {
 			"version": "7.15.4",
@@ -2473,9 +2488,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
 		},
 		"@babel/helper-validator-option": {
 			"version": "7.14.5",
@@ -2554,23 +2569,31 @@
 			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+			"integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.16.7"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
-			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
+			"version": "7.17.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+			"integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.14.5",
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/plugin-syntax-jsx": "^7.14.5",
-				"@babel/types": "^7.14.9"
+				"@babel/helper-annotate-as-pure": "^7.16.7",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/helper-plugin-utils": "^7.16.7",
+				"@babel/plugin-syntax-jsx": "^7.16.7",
+				"@babel/types": "^7.17.0"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-development": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
+			"integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+			"requires": {
+				"@babel/plugin-transform-react-jsx": "^7.16.7"
 			}
 		},
 		"@babel/template": {
@@ -2600,11 +2623,11 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-			"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+			"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"to-fast-properties": "^2.0.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	],
 	"dependencies": {
 		"@babel/plugin-transform-react-jsx": "^7.14.9",
+		"@babel/plugin-transform-react-jsx-development": "^7.16.7",
 		"@prefresh/vite": "^2.2.6",
 		"@rollup/pluginutils": "^4.1.1",
 		"babel-plugin-transform-hook-names": "^1.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,9 @@ export default function preactPlugin({
 				},
 				plugins: [
 					[
-						"@babel/plugin-transform-react-jsx",
+						config.isProduction
+							? "@babel/plugin-transform-react-jsx"
+							: "@babel/plugin-transform-react-jsx-development",
 						{
 							runtime: "automatic",
 							importSource: "preact",


### PR DESCRIPTION
This PR adds the babel plugin to transpile jsx to `jsxDEV` calls. Noticed that we used the [wrong argument order](https://github.com/preactjs/preact/pull/3459) in Preact for that transform too.

Fixes #40 