### PR TITLE
Add support for custom babel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ export default defineConfig({
 |---|---|---|---|
 | `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
 
+### Babel configuration
+
+The `babel` option lets you add plugins, presets, and [other configuration](https://babeljs.io/docs/en/options) to the Babel transformation performed on each JSX/TSX file.
+
+```js
+preact({
+  babel: {
+    presets: [...],
+    // Your plugins run before any built-in transform (eg: Fast Refresh)
+    plugins: [...],
+    // Use .babelrc files
+    babelrc: true,
+    // Use babel.config.js files
+    configFile: true,
+  }
+})
+```
+
 ## License
 
 MIT, see [the license file](./LICENSE).


### PR DESCRIPTION
I currently ran into an issue that legacy-decorators are not supported (same as #43) and I fixed it by adding the `@babel/plugin-proposal-decorators` and `@babel/plugin-proposal-class-properties`.

Unfortunately I had to inject these plugins directly into the packages source code. So I thought it would be nice to have an option to change babel config in vites config file.