### PR TITLE
add named export to improve `"module": "nodenext"` compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js"
+			"require": "./dist/cjs/index.js",
+			"types": "./dist/types/index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export interface PreactBabelOptions extends BabelOptions {
 }
 
 // Taken from https://github.com/vitejs/vite/blob/main/packages/plugin-react/src/index.ts
-export default function preactPlugin({
+function preactPlugin({
 	devtoolsInProd,
 	include,
 	exclude,
@@ -187,3 +187,5 @@ export default function preactPlugin({
 		prefresh({ include, exclude }),
 	];
 }
+
+export { preactPlugin as default, preactPlugin as preact };

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,4 +188,5 @@ function preactPlugin({
 	];
 }
 
-export { preactPlugin as default, preactPlugin as preact };
+export default preactPlugin;
+export { preactPlugin as preact };


### PR DESCRIPTION
* see https://github.com/microsoft/TypeScript/issues/48845