### PR TITLE
fix: support vite v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"vite": "2.x"
+		"vite": "2.x || 3.x"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.15.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import type { FilterPattern } from "@rollup/pluginutils";
 import type { ParserPlugin, ParserOptions } from "@babel/parser";
 import type { TransformOptions } from "@babel/core";
 
-import resolve from "resolve";
 import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools.js";
 import { createFilter, parseId } from "./utils.js";
@@ -88,24 +87,6 @@ export default function preactPlugin({
 		},
 		configResolved(resolvedConfig) {
 			config = resolvedConfig;
-		},
-		resolveId(id: string) {
-			return id === "preact/jsx-runtime" ? id : null;
-		},
-		load(id: string) {
-			if (id === "preact/jsx-runtime") {
-				const runtimePath = resolve.sync("preact/jsx-runtime", {
-					basedir: config.root,
-				});
-				const exports = ["jsx", "jsxs", "Fragment"];
-				return [
-					`import * as jsxRuntime from ${JSON.stringify(runtimePath)}`,
-					// We can't use `export * from` or else any callsite that uses
-					// this module will be compiled to `jsxRuntime.exports.jsx`
-					// instead of the more concise `jsx` alias.
-					...exports.map(name => `export const ${name} = jsxRuntime.${name}`),
-				].join("\n");
-			}
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.


### PR DESCRIPTION
preact provides `exports` field and `module` field so it worked without interop codes.
This PR removes them because it was causing issues with Vite v3.

fixes https://github.com/preactjs/preset-vite/issues/52

I tested with Vite (3.0.0-beta.1, 2.9.12) and preact (10.8.2, 10.7.0) with reproduction on https://github.com/preactjs/preset-vite/issues/49.
