### PR TITLE
perf: add entries to optimizeDeps

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -27,6 +27,14 @@ export function preactDevtoolsPlugin({
 		// Ensure that we resolve before everything else
 		enforce: "pre",
 
+		config() {
+			return {
+				optimizeDeps: {
+					include: ["preact/debug", "preact/devtools"],
+				},
+			};
+		},
+
 		configResolved(resolvedConfig) {
 			config = resolvedConfig;
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export default function preactPlugin({
 		config() {
 			return {
 				optimizeDeps: {
-					include: ["preact/jsx-runtime"],
+					include: ["preact/jsx-runtime", "preact/jsx-dev-runtime"],
 				},
 			};
 		},


### PR DESCRIPTION
Adding entries to `optimizeDeps` will prevent these happening and it will reduce start up time.
```text
[vite] ✨ new dependencies optimized: preact/debug, preact/jsx-dev-runtime
[vite] ✨ optimized dependencies changed. reloading
```
This PR adds `preact/jsx-dev-runtime`, `preact/debug`, `preact/devtools` to `optimizeDeps`.
