### PR TITLE
docs: Mention automatic aliasing as feature in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Features:
 
 - Sets up Hot Module Replacement via [prefresh](https://github.com/JoviDeCroock/prefresh/tree/main/packages/vite)
 - Enables [Preact Devtools](https://preactjs.github.io/preact-devtools/) bridge during development
+- Aliases React to `preact/compat`
 
 ## Installation
 


### PR DESCRIPTION
I think we forgot to mention that we set this alias by default; no need for users to do it themselves.