### PR TITLE
Provide options to disable devtools and prefresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ export default defineConfig({
 
 | Option | Type | Default | Description |
 |---|---|---|---|
+| `devToolsEnabled` | `boolean` | `true` | Inject devtools bridge |
+| `prefreshEnabled` | `boolean` | `true` | Inject [Prefresh](https://github.com/preactjs/prefresh) for HMR |
 | `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
 
 ### Babel configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,14 +183,14 @@ function preactPlugin({
 		},
 		jsxPlugin,
 		...(devToolsEnabled
-			? []
-			: [
+			? [
 					preactDevtoolsPlugin({
 						injectInProd: devtoolsInProd,
 						shouldTransform,
 					}),
-			  ]),
-		...(prefreshEnabled ? [] : [prefresh({ include, exclude })]),
+			  ]
+			: []),
+		...(prefreshEnabled ? [prefresh({ include, exclude })] : []),
 	];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ function preactPlugin({
 			};
 		},
 	};
-	const plugins = [
+	return [
 		{
 			name: "preact:config",
 			config() {
@@ -182,17 +182,16 @@ function preactPlugin({
 			},
 		},
 		jsxPlugin,
+		...(devToolsEnabled
+			? []
+			: [
+					preactDevtoolsPlugin({
+						injectInProd: devtoolsInProd,
+						shouldTransform,
+					}),
+			  ]),
+		...(prefreshEnabled ? [] : [prefresh({ include, exclude })]),
 	];
-
-	if (devToolsEnabled) {
-		plugins.push(
-			preactDevtoolsPlugin({ injectInProd: devtoolsInProd, shouldTransform }),
-		);
-	}
-	if (prefreshEnabled) {
-		plugins.push(prefresh({ include, exclude }));
-	}
-	return plugins;
 }
 
 export default preactPlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,19 @@ export interface PreactPluginOptions {
 	 * @default false
 	 */
 	devtoolsInProd?: boolean;
+
+	/**
+	 * Whether to use Preact devtools
+	 * @default true
+	 */
+	devToolsEnabled?: boolean;
+
+	/**
+	 * Whether to use prefresh HMR
+	 * @default true
+	 */
+	prefreshEnabled?: boolean;
+
 	/**
 	 * RegExp or glob to match files to be transformed
 	 */
@@ -52,6 +65,8 @@ export interface PreactBabelOptions extends BabelOptions {
 // Taken from https://github.com/vitejs/vite/blob/main/packages/plugin-react/src/index.ts
 function preactPlugin({
 	devtoolsInProd,
+	devToolsEnabled,
+	prefreshEnabled,
 	include,
 	exclude,
 	babel,
@@ -74,6 +89,9 @@ function preactPlugin({
 		include || [/\.[tj]sx?$/],
 		exclude || [/node_modules/],
 	);
+
+	devToolsEnabled = devToolsEnabled ?? true;
+	prefreshEnabled = prefreshEnabled ?? true;
 
 	const jsxPlugin: Plugin = {
 		name: "vite:preact-jsx",
@@ -148,7 +166,7 @@ function preactPlugin({
 			};
 		},
 	};
-	return [
+	const plugins = [
 		{
 			name: "preact:config",
 			config() {
@@ -164,9 +182,17 @@ function preactPlugin({
 			},
 		},
 		jsxPlugin,
-		preactDevtoolsPlugin({ injectInProd: devtoolsInProd, shouldTransform }),
-		prefresh({ include, exclude }),
 	];
+
+	if (devToolsEnabled) {
+		plugins.push(
+			preactDevtoolsPlugin({ injectInProd: devtoolsInProd, shouldTransform }),
+		);
+	}
+	if (prefreshEnabled) {
+		plugins.push(prefresh({ include, exclude }));
+	}
+	return plugins;
 }
 
 export default preactPlugin;


### PR DESCRIPTION
Add two top-level options to disable either Dev Tools or Prefresh.
Both are great tools, but I have a use-case where I only need the basic Preact compatibility layer without the extra features.

