### PR TITLE
Upgrade TypeScript target to ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"target": "ES2019",
 		"strict": true,
 		"esModuleInterop": true,
 		"module": "ESNext",


### PR DESCRIPTION
Vite's min Node version is 14 so we can ship higher level JS then TypeScript's default. I believe ES2019 is a safe version to use. I didn't thoroughly check if we could go higher.

Doing this means we no longer down compile async/await to TS's manual state machine and instead ship native async/await.