### PR TITLE
Update peerDependencies to support Vite 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
-				"vite": "2.x || 3.x"
+				"vite": "2.x || 3.x || 4.x"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"vite": "2.x || 3.x"
+		"vite": "2.x || 3.x || 4.x"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.15.8",


### PR DESCRIPTION
Hi, as explained in issue #68 when you go to use this plugin an error is thrown because there is no Vite 4 support declaration. I checked the various breaking changes of both Vite and Rollup and it seems that there are no changes to be made to this plugin. 
I also used the output on my project and everything worked.
closes #68 