### PR TITLE
chore: Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
My defaults differ quite a bit from the style here, this helps keep the diff sane 😅

A bit different than [the "standard" config we have in core](https://github.com/preactjs/preact/blob/main/.editorconfig) but I think it matches the style here correctly.