### PR TITLE
feat: prerender plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ export default defineConfig({
 
 | Option | Type | Default | Description |
 |---|---|---|---|
+| `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
 | `devToolsEnabled` | `boolean` | `true` | Inject devtools bridge |
 | `prefreshEnabled` | `boolean` | `true` | Inject [Prefresh](https://github.com/preactjs/prefresh) for HMR |
-| `devtoolsInProd` | `boolean` | `false` | Inject devtools bridge in production bundle instead of only in development mode |
 | `reactAliasesEnabled` | `boolean` | `true` | Aliases `react`, `react-dom` to `preact/compat` |
+| `babel` | `object` | | See [Babel configuration](#babel-configuration) |
+| `prerender` | `object` | | See [Prerendering configuration](#prerendering-configuration) |
 
-### Babel configuration
+#### Babel configuration
 
 The `babel` option lets you add plugins, presets, and [other configuration](https://babeljs.io/docs/en/options) to the Babel transformation performed on each JSX/TSX file.
 
@@ -66,6 +68,49 @@ preact({
     configFile: true,
   }
 })
+```
+
+#### Prerendering configuration
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `boolean` | `false` | Enables prerendering |
+| `prerenderScript` | `string` | `undefined` | Absolute path to script containing exported `prerender()` function. If not provided, will try to find the prerender script in the scripts listed in your HTML entrypoint |
+| `additionalPrerenderRoutes` | `string` | `undefined` | Prerendering will automatically discover links to prerender, but if there are unliked pages that you want to prererender (such as a `/404` page), use this option to specify them |
+
+To prerender your app, you'll need to set `prerender.enabled` to `true` and export a `prerender()` function one of the scripts listed in your HTML entry point (or the script specified through `prerender.prerenderScript`). How precisely you generate an HTML string from your app is up to you, but you'll likely want to use [`preact-render-to-string`](https://github.com/preactjs/preact-render-to-string) or a wrapper around it such as [`preact-iso`'s `prerender`](https://github.com/preactjs/preact-iso). Whatever you choose, you simply need to return an object from your `prerender()` function containing an `html` property with your HTML string.
+
+[For an example implementation, see our demo](./demo/src/index.tsx)
+
+```js
+import { render } from 'preact-render-to-string';
+
+export async function prerender(data) {
+    // Do prerendering here.
+    const html = render(`<h1>hello world</h1>`);
+
+    return {
+        html,
+        // Optionally add additional links that should be
+        // prerendered (if they haven't already been)
+        links: new Set(['/foo', '/bar']),
+        // Optionally configure and add elements to the `<head>` of
+        // the prerendered HTML document
+        head: {
+            // Sets the "lang" attribute: `<html lang="en">`
+            lang: 'en',
+            // Sets the title for the current page: `<title>My cool page</title>`
+            title: 'My cool page',
+            // Sets any additional elements you want injected into the `<head>`:
+            //   <link rel="stylesheet" href="foo.css">
+            //   <meta property="og:title" content="Social media title">
+            elements: new Set([
+                { type: 'link', props: { rel: 'stylesheet', href: 'foo.css' } },
+                { type: 'meta', props: { property: 'og:title', content: 'Social media title' } }
+            ])
+        }
+    };
+}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ To prerender your app, you'll need to set `prerender.enabled` to `true` and expo
 import { render } from 'preact-render-to-string';
 
 export async function prerender(data) {
-    // Do prerendering here.
     const html = render(`<h1>hello world</h1>`);
 
     return {

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ preact({
 |---|---|---|---|
 | `enabled` | `boolean` | `false` | Enables prerendering |
 | `prerenderScript` | `string` | `undefined` | Absolute path to script containing exported `prerender()` function. If not provided, will try to find the prerender script in the scripts listed in your HTML entrypoint |
+| `renderTarget` | `string` | `"body"` | Query selector for where to insert prerender result in your HTML template |
 | `additionalPrerenderRoutes` | `string` | `undefined` | Prerendering will automatically discover links to prerender, but if there are unliked pages that you want to prererender (such as a `/404` page), use this option to specify them |
 
 To prerender your app, you'll need to set `prerender.enabled` to `true` and export a `prerender()` function one of the scripts listed in your HTML entry point (or the script specified through `prerender.prerenderScript`). How precisely you generate an HTML string from your app is up to you, but you'll likely want to use [`preact-render-to-string`](https://github.com/preactjs/preact-render-to-string) or a wrapper around it such as [`preact-iso`'s `prerender`](https://github.com/preactjs/preact-iso). Whatever you choose, you simply need to return an object from your `prerender()` function containing an `html` property with your HTML string.

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,6 @@
 		<title>Vite + Preact</title>
 	</head>
 	<body>
-		<div id="app"></div>
 		<script type="module" src="/src/index.tsx"></script>
 	</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,7 @@
 		<title>Vite + Preact</title>
 	</head>
 	<body>
+		<div id="app"></div>
 		<script type="module" src="/src/index.tsx"></script>
 	</body>
 </html>

--- a/demo/public/local-fetch-test.txt
+++ b/demo/public/local-fetch-test.txt
@@ -1,0 +1,1 @@
+Local fetch works

--- a/demo/src/components/LocalFetch.tsx
+++ b/demo/src/components/LocalFetch.tsx
@@ -1,0 +1,32 @@
+import { useState } from "preact/hooks";
+
+const cache = new Map();
+
+async function load(url: string) {
+	const res = await fetch(url);
+	return await res.text();
+}
+
+function useFetch(url: string) {
+	const [_, update] = useState({});
+
+	let data = cache.get(url);
+	if (!data) {
+		data = load(url);
+		cache.set(url, data);
+		data.then(
+			(res: string) => update((data.res = res)),
+			(err: Error) => update((data.err = err)),
+		);
+	}
+
+	if (data.res) return data.res;
+	if (data.err) throw data.err;
+	throw data;
+}
+
+export function LocalFetch() {
+	const data = useFetch("/local-fetch-test.txt");
+
+	return <p>{data.trimEnd()}</p>;
+}

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -25,7 +25,9 @@ export function App() {
 	);
 }
 
-hydrate(<App />);
+if (typeof window !== "undefined") {
+	hydrate(<App />, document.getElementById("app"));
+}
 
 export async function prerender() {
 	const { html, links } = await ssr(<App />);

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -1,5 +1,4 @@
-import { render } from "preact";
-import { LocationProvider, Router, Route } from "preact-iso";
+import { LocationProvider, Router, Route, hydrate, prerender as ssr } from "preact-iso";
 
 import { Header } from "./components/Header.jsx";
 import { Home } from "./pages/Home/index.jsx";
@@ -20,4 +19,8 @@ export function App() {
 	);
 }
 
-render(<App />, document.getElementById("app")!);
+hydrate(<App />);
+
+export async function prerender() {
+	return await ssr(<App />);
+}

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -1,4 +1,10 @@
-import { LocationProvider, Router, Route, hydrate, prerender as ssr } from "preact-iso";
+import {
+	LocationProvider,
+	Router,
+	Route,
+	hydrate,
+	prerender as ssr,
+} from "preact-iso";
 
 import { Header } from "./components/Header.jsx";
 import { Home } from "./pages/Home/index.jsx";
@@ -22,5 +28,22 @@ export function App() {
 hydrate(<App />);
 
 export async function prerender() {
-	return await ssr(<App />);
+	const { html, links } = await ssr(<App />);
+	return {
+		html,
+		links,
+		head: {
+			lang: "en",
+			title: "Prerendered Preact App",
+			elements: new Set([
+				{
+					type: "meta",
+					props: {
+						name: "description",
+						content: "This is a prerendered Preact app",
+					},
+				},
+			]),
+		},
+	};
 }

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -34,7 +34,6 @@ export async function prerender() {
 	return {
 		html,
 		links,
-		renderTarget: "#app",
 		head: {
 			lang: "en",
 			title: "Prerendered Preact App",

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -34,7 +34,7 @@ export async function prerender() {
 	return {
 		html,
 		links,
-		selector: "#app",
+		renderTarget: "#app",
 		head: {
 			lang: "en",
 			title: "Prerendered Preact App",

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -34,6 +34,7 @@ export async function prerender() {
 	return {
 		html,
 		links,
+		selector: "#app",
 		head: {
 			lang: "en",
 			title: "Prerendered Preact App",

--- a/demo/src/pages/Home/index.tsx
+++ b/demo/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
 import { ReactComponent } from "../../components/Compat";
+import { LocalFetch } from "../../components/LocalFetch";
 
 import preactLogo from "../../assets/preact.svg";
 import "./style.css";
@@ -11,6 +12,7 @@ export function Home() {
 			</a>
 			<h1>Get Started building Vite-powered Preact Apps </h1>
 			<ReactComponent />
+			<LocalFetch />
 			<section>
 				<Resource
 					title="Learn Preact"

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -3,5 +3,5 @@ import preact from "../src/index";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [preact()],
+	plugins: [preact({ prerender: { enabled: true } })],
 });

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -3,5 +3,9 @@ import preact from "../src/index";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [preact({ prerender: { enabled: true } })],
+	plugins: [
+		preact({
+			prerender: { enabled: true, additionalPrerenderRoutes: ["/404"] },
+		}),
+	],
 });

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -5,7 +5,11 @@ import preact from "../src/index";
 export default defineConfig({
 	plugins: [
 		preact({
-			prerender: { enabled: true, additionalPrerenderRoutes: ["/404"] },
+			prerender: {
+				enabled: true,
+				renderTarget: "#app",
+				additionalPrerenderRoutes: ["/404"],
+			},
 		}),
 	],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
 				"debug": "^4.3.4",
 				"kolorist": "^1.8.0",
 				"node-html-parser": "^6.1.10",
-				"resolve": "^1.22.8"
+				"resolve": "^1.22.8",
+				"rs-module-lexer": "^2.1.1"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.15.8",
@@ -660,6 +661,141 @@
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
 			"integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
 			"dev": true
+		},
+		"node_modules/@xn-sakina/rml-darwin-arm64": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-darwin-arm64/-/rml-darwin-arm64-2.1.1.tgz",
+			"integrity": "sha512-Ljog63oD8+riz/3zLN0pAgvJSaFTpJY4KxrH+TJnfEbUoRb7ZhmGEpYGl5imi43/9yNkGyAoF41ysIHxg0yEAw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-darwin-x64": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-darwin-x64/-/rml-darwin-x64-2.1.1.tgz",
+			"integrity": "sha512-uLeZKZFiygZntppOjbfGzU3YsFmx4joW/6UlKfCKwelrTrtKa3bYMz55NuFc2RW7IuuNrGEILwz+ZPUdfv3ykA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-linux-arm-gnueabihf": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm-gnueabihf/-/rml-linux-arm-gnueabihf-2.1.1.tgz",
+			"integrity": "sha512-Ou/h5ma/jsbgcWS//BdRh4bb/5RFRjebc1Yrlm6iyqSRNJqnY58hEl8pc9feOSkrjorvc8aAe5CWZPf7sZrzrA==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-linux-arm64-gnu": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm64-gnu/-/rml-linux-arm64-gnu-2.1.1.tgz",
+			"integrity": "sha512-hmNtRDxxNc9LVEr/tlzgHOG2wKM0w1rPdIu2zvIVpVi8JUFcenEcHGLrezFlQg8NK/BMQiAmMmMpxhB9Mr4wpA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-linux-arm64-musl": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm64-musl/-/rml-linux-arm64-musl-2.1.1.tgz",
+			"integrity": "sha512-sYY5m7fK1VhLodt4IDB+XSTmvu2g0D5VbT30RpBhXlL3CI37fgLyNvO+NSn9J6b4xrGqzdkIv677JfkhM9hHGw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-linux-x64-gnu": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-x64-gnu/-/rml-linux-x64-gnu-2.1.1.tgz",
+			"integrity": "sha512-n9Q6DOUgc6U05YqgnwKmpMdrKk3K4JtUpB6Wee3kyxrQr1FKT6E5FXqzzO2q62AxXqWsc1WVNE6IWldURUI2Bg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-linux-x64-musl": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-x64-musl/-/rml-linux-x64-musl-2.1.1.tgz",
+			"integrity": "sha512-4qq3jw6jqrL0L1A3Q1zIIl1392uamXycb6gws+RsWnNnaogVHa/QD47w9xTsVRVYqEfsroV+84OOvNSpaoBrQQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-win32-arm64-msvc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-win32-arm64-msvc/-/rml-win32-arm64-msvc-2.1.1.tgz",
+			"integrity": "sha512-QnsttcVOMvetJ0xZOsUSZ38hpAbydDGl4MwY4yGvKK0/6XbirKEq/bn3Zl9ABLX3elLaE/pghGSlxB9fsk70Qw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@xn-sakina/rml-win32-x64-msvc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-win32-x64-msvc/-/rml-win32-x64-msvc-2.1.1.tgz",
+			"integrity": "sha512-AnNynVvyfp3mBUA0fQFqBth13pFcRjOhCDieF73UYYH3xDc/mowtjDO+kUWW9EtZH94CPDkT1Ei9WWESruOg6w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
@@ -2030,6 +2166,26 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rs-module-lexer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/rs-module-lexer/-/rs-module-lexer-2.1.1.tgz",
+			"integrity": "sha512-6F5a6PS3PJ/qZ0o+FKFcqABFBVsaMIOEMA4yBFyAwJnCpQ6a8CIk+ln3pRPrl0N2k6HgAupzXpQq4NuTVg5haQ==",
+			"hasInstallScript": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"@xn-sakina/rml-darwin-arm64": "2.1.1",
+				"@xn-sakina/rml-darwin-x64": "2.1.1",
+				"@xn-sakina/rml-linux-arm-gnueabihf": "2.1.1",
+				"@xn-sakina/rml-linux-arm64-gnu": "2.1.1",
+				"@xn-sakina/rml-linux-arm64-musl": "2.1.1",
+				"@xn-sakina/rml-linux-x64-gnu": "2.1.1",
+				"@xn-sakina/rml-linux-x64-musl": "2.1.1",
+				"@xn-sakina/rml-win32-arm64-msvc": "2.1.1",
+				"@xn-sakina/rml-win32-x64-msvc": "2.1.1"
 			}
 		},
 		"node_modules/rxjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"preact-render-to-string": "^6.3.1",
 				"prettier": "^2.2.1",
 				"rimraf": "^3.0.2",
+				"rollup": "^2.77.3",
 				"simple-git-hooks": "^2.0.2",
 				"ts-node": "^9.1.1",
 				"typescript": "^4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.3.4",
 				"kolorist": "^1.8.0",
+				"magic-string": "0.30.5",
 				"node-html-parser": "^6.1.10",
 				"resolve": "^1.22.8",
 				"rs-module-lexer": "^2.1.1"
@@ -28,7 +29,6 @@
 				"@types/node": "^14.14.33",
 				"@types/resolve": "^1.20.1",
 				"lint-staged": "^10.5.4",
-				"magic-string": "^0.30.5",
 				"preact": "^10.19.2",
 				"preact-iso": "^2.3.2",
 				"preact-render-to-string": "^6.3.1",
@@ -42,7 +42,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
-				"magic-string": "0.x",
 				"vite": "2.x || 3.x || 4.x || 5.x"
 			}
 		},
@@ -1762,7 +1761,6 @@
 			"version": "0.30.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
 			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
-				"magic-string": "0.*",
+				"magic-string": "0.x",
 				"vite": "2.x || 3.x || 4.x || 5.x"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
 	"name": "@preact/preset-vite",
 	"version": "2.7.0",
-	"lockfileVersion": 3,
+	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
@@ -499,6 +499,21 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1300,6 +1315,111 @@
 				"esbuild-windows-arm64": "0.14.54"
 			}
 		},
+		"node_modules/esbuild-android-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-android-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-darwin-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-darwin-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-freebsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-freebsd-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/esbuild-linux-64": {
 			"version": "0.14.54",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
@@ -1310,6 +1430,186 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-arm": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-mips64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-ppc64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-riscv64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"cpu": [
+				"riscv64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-s390x": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-netbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-openbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-sunos-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-windows-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-windows-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-windows-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -1391,6 +1691,19 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -1837,9 +2150,9 @@
 			}
 		},
 		"node_modules/node-html-parser": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.11.tgz",
-			"integrity": "sha512-FAgwwZ6h0DSDWxfD0Iq1tsDcBCxdJB1nXpLPPxX8YyVWzbfCjKWEzaynF4gZZ/8hziUmp7ZSaKylcn0iKhufUQ==",
+			"version": "6.1.12",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.12.tgz",
+			"integrity": "sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==",
 			"dependencies": {
 				"css-select": "^5.1.0",
 				"he": "1.2.0"
@@ -2579,6 +2892,1896 @@
 			"engines": {
 				"node": ">=6"
 			}
+		}
+	},
+	"dependencies": {
+		"@ampproject/remapping": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"requires": {
+				"@babel/highlight": "^7.22.13",
+				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+			"integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ=="
+		},
+		"@babel/core": {
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+			"requires": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helpers": "^7.23.2",
+				"@babel/parser": "^7.23.0",
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+			"requires": {
+				"@babel/types": "^7.23.0",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
+				"jsesc": "^2.5.1"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"requires": {
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-validator-option": "^7.22.15",
+				"browserslist": "^4.21.9",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
+		},
+		"@babel/helper-function-name": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+			"requires": {
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"requires": {
+				"@babel/types": "^7.22.15"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+			"requires": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg=="
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+			"requires": {
+				"@babel/types": "^7.22.5"
+			}
+		},
+		"@babel/helper-string-parser": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA=="
+		},
+		"@babel/helpers": {
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+			"requires": {
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.22.5"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
+			"integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.22.5",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/plugin-syntax-jsx": "^7.22.5",
+				"@babel/types": "^7.22.15"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-development": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
+			"integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
+			"requires": {
+				"@babel/plugin-transform-react-jsx": "^7.22.5"
+			}
+		},
+		"@babel/template": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"requires": {
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+			"requires": {
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/types": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"requires": {
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@esbuild/linux-loong64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"optional": true
+		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"requires": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"@prefresh/babel-plugin": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.0.tgz",
+			"integrity": "sha512-joAwpkUDwo7ZqJnufXRGzUb+udk20RBgfA8oLPBh5aJH2LeStmV1luBfeJTztPdyCscC2j2SmZ/tVxFRMIxAEw=="
+		},
+		"@prefresh/core": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.2.tgz",
+			"integrity": "sha512-A/08vkaM1FogrCII5PZKCrygxSsc11obExBScm3JF1CryK2uDS3ZXeni7FeKCx1nYdUkj4UcJxzPzc1WliMzZA==",
+			"requires": {}
+		},
+		"@prefresh/utils": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.0.tgz",
+			"integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ=="
+		},
+		"@prefresh/vite": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.1.tgz",
+			"integrity": "sha512-vthWmEqu8TZFeyrBNc9YE5SiC3DVSzPgsOCp/WQ7FqdHpOIJi7Z8XvCK06rBPOtG4914S52MjG9Ls22eVAiuqQ==",
+			"requires": {
+				"@babel/core": "^7.22.1",
+				"@prefresh/babel-plugin": "0.5.0",
+				"@prefresh/core": "^1.5.1",
+				"@prefresh/utils": "^1.2.0",
+				"@rollup/pluginutils": "^4.2.1"
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"requires": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.14",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+			"integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+			"integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/debug": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+			"dev": true
+		},
+		"@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+			"dev": true
+		},
+		"@types/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
+			"integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
+			"dev": true
+		},
+		"@xn-sakina/rml-darwin-arm64": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-darwin-arm64/-/rml-darwin-arm64-2.1.1.tgz",
+			"integrity": "sha512-Ljog63oD8+riz/3zLN0pAgvJSaFTpJY4KxrH+TJnfEbUoRb7ZhmGEpYGl5imi43/9yNkGyAoF41ysIHxg0yEAw==",
+			"optional": true
+		},
+		"@xn-sakina/rml-darwin-x64": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-darwin-x64/-/rml-darwin-x64-2.1.1.tgz",
+			"integrity": "sha512-uLeZKZFiygZntppOjbfGzU3YsFmx4joW/6UlKfCKwelrTrtKa3bYMz55NuFc2RW7IuuNrGEILwz+ZPUdfv3ykA==",
+			"optional": true
+		},
+		"@xn-sakina/rml-linux-arm-gnueabihf": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm-gnueabihf/-/rml-linux-arm-gnueabihf-2.1.1.tgz",
+			"integrity": "sha512-Ou/h5ma/jsbgcWS//BdRh4bb/5RFRjebc1Yrlm6iyqSRNJqnY58hEl8pc9feOSkrjorvc8aAe5CWZPf7sZrzrA==",
+			"optional": true
+		},
+		"@xn-sakina/rml-linux-arm64-gnu": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm64-gnu/-/rml-linux-arm64-gnu-2.1.1.tgz",
+			"integrity": "sha512-hmNtRDxxNc9LVEr/tlzgHOG2wKM0w1rPdIu2zvIVpVi8JUFcenEcHGLrezFlQg8NK/BMQiAmMmMpxhB9Mr4wpA==",
+			"optional": true
+		},
+		"@xn-sakina/rml-linux-arm64-musl": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-arm64-musl/-/rml-linux-arm64-musl-2.1.1.tgz",
+			"integrity": "sha512-sYY5m7fK1VhLodt4IDB+XSTmvu2g0D5VbT30RpBhXlL3CI37fgLyNvO+NSn9J6b4xrGqzdkIv677JfkhM9hHGw==",
+			"optional": true
+		},
+		"@xn-sakina/rml-linux-x64-gnu": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-x64-gnu/-/rml-linux-x64-gnu-2.1.1.tgz",
+			"integrity": "sha512-n9Q6DOUgc6U05YqgnwKmpMdrKk3K4JtUpB6Wee3kyxrQr1FKT6E5FXqzzO2q62AxXqWsc1WVNE6IWldURUI2Bg==",
+			"optional": true
+		},
+		"@xn-sakina/rml-linux-x64-musl": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-linux-x64-musl/-/rml-linux-x64-musl-2.1.1.tgz",
+			"integrity": "sha512-4qq3jw6jqrL0L1A3Q1zIIl1392uamXycb6gws+RsWnNnaogVHa/QD47w9xTsVRVYqEfsroV+84OOvNSpaoBrQQ==",
+			"optional": true
+		},
+		"@xn-sakina/rml-win32-arm64-msvc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-win32-arm64-msvc/-/rml-win32-arm64-msvc-2.1.1.tgz",
+			"integrity": "sha512-QnsttcVOMvetJ0xZOsUSZ38hpAbydDGl4MwY4yGvKK0/6XbirKEq/bn3Zl9ABLX3elLaE/pghGSlxB9fsk70Qw==",
+			"optional": true
+		},
+		"@xn-sakina/rml-win32-x64-msvc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@xn-sakina/rml-win32-x64-msvc/-/rml-win32-x64-msvc-2.1.1.tgz",
+			"integrity": "sha512-AnNynVvyfp3mBUA0fQFqBth13pFcRjOhCDieF73UYYH3xDc/mowtjDO+kUWW9EtZH94CPDkT1Ei9WWESruOg6w==",
+			"optional": true
+		},
+		"aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.11.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true
+		},
+		"babel-plugin-transform-hook-names": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
+			"integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
+			"requires": {}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
+		"browserslist": {
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001541",
+				"electron-to-chromium": "^1.4.535",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.13"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001547",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
+			"integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA=="
+		},
+		"chalk": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
+		"cli-truncate": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+			"dev": true,
+			"requires": {
+				"slice-ansi": "^3.0.0",
+				"string-width": "^4.2.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"commander": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+		},
+		"cosmiconfig": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"dev": true,
+			"requires": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			}
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			}
+		},
+		"css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true
+		},
+		"dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"requires": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			}
+		},
+		"domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+		},
+		"domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"requires": {
+				"domelementtype": "^2.3.0"
+			}
+		},
+		"domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"requires": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.4.553",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.553.tgz",
+			"integrity": "sha512-HiRdtyKS2+VhiXvjhMvvxiMC33FJJqTA5EB2YHgFZW6v7HkK4Q9Ahv2V7O2ZPgAjw+MyCJVMQvigj13H8t+wvA=="
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
+			}
+		},
+		"entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"esbuild": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+			"requires": {
+				"@esbuild/linux-loong64": "0.14.54",
+				"esbuild-android-64": "0.14.54",
+				"esbuild-android-arm64": "0.14.54",
+				"esbuild-darwin-64": "0.14.54",
+				"esbuild-darwin-arm64": "0.14.54",
+				"esbuild-freebsd-64": "0.14.54",
+				"esbuild-freebsd-arm64": "0.14.54",
+				"esbuild-linux-32": "0.14.54",
+				"esbuild-linux-64": "0.14.54",
+				"esbuild-linux-arm": "0.14.54",
+				"esbuild-linux-arm64": "0.14.54",
+				"esbuild-linux-mips64le": "0.14.54",
+				"esbuild-linux-ppc64le": "0.14.54",
+				"esbuild-linux-riscv64": "0.14.54",
+				"esbuild-linux-s390x": "0.14.54",
+				"esbuild-netbsd-64": "0.14.54",
+				"esbuild-openbsd-64": "0.14.54",
+				"esbuild-sunos-64": "0.14.54",
+				"esbuild-windows-32": "0.14.54",
+				"esbuild-windows-64": "0.14.54",
+				"esbuild-windows-arm64": "0.14.54"
+			}
+		},
+		"esbuild-android-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"optional": true
+		},
+		"esbuild-android-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"optional": true
+		},
+		"esbuild-darwin-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"optional": true
+		},
+		"esbuild-darwin-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"optional": true
+		},
+		"esbuild-freebsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"optional": true
+		},
+		"esbuild-freebsd-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"optional": true
+		},
+		"esbuild-linux-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"optional": true
+		},
+		"esbuild-linux-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+			"optional": true
+		},
+		"esbuild-linux-arm": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"optional": true
+		},
+		"esbuild-linux-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"optional": true
+		},
+		"esbuild-linux-mips64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"optional": true
+		},
+		"esbuild-linux-ppc64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"optional": true
+		},
+		"esbuild-linux-riscv64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"optional": true
+		},
+		"esbuild-linux-s390x": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"optional": true
+		},
+		"esbuild-netbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"optional": true
+		},
+		"esbuild-openbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"optional": true
+		},
+		"esbuild-sunos-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"optional": true
+		},
+		"esbuild-windows-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"optional": true
+		},
+		"esbuild-windows-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"optional": true
+		},
+		"esbuild-windows-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"optional": true
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
+		"execa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
+			}
+		},
+		"figures": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"optional": true
+		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+		},
+		"get-own-enumerable-property-symbols": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ=="
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+		},
+		"human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+			"integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+		},
+		"kolorist": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
+		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
+		},
+		"lint-staged": {
+			"version": "10.5.4",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
+			"integrity": "sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"cli-truncate": "^2.1.0",
+				"commander": "^6.2.0",
+				"cosmiconfig": "^7.0.0",
+				"debug": "^4.2.0",
+				"dedent": "^0.7.0",
+				"enquirer": "^2.3.6",
+				"execa": "^4.1.0",
+				"listr2": "^3.2.2",
+				"log-symbols": "^4.0.0",
+				"micromatch": "^4.0.2",
+				"normalize-path": "^3.0.0",
+				"please-upgrade-node": "^3.2.0",
+				"string-argv": "0.3.1",
+				"stringify-object": "^3.3.0"
+			}
+		},
+		"listr2": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.4.3.tgz",
+			"integrity": "sha512-wZmkzNiuinOfwrGqAwTCcPw6aKQGTAMGXwG5xeU1WpDjJNeBA35jGBeWxR3OF+R6Yl5Y3dRG+3vE8t6PDcSNHA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"cli-truncate": "^2.1.0",
+				"figures": "^3.2.0",
+				"indent-string": "^4.0.0",
+				"log-update": "^4.0.0",
+				"p-map": "^4.0.0",
+				"rxjs": "^6.6.6",
+				"through": "^2.3.8",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"log-symbols": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0"
+			}
+		},
+		"log-update": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+			"integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.3.0",
+				"cli-cursor": "^3.1.0",
+				"slice-ansi": "^4.0.0",
+				"wrap-ansi": "^6.2.0"
+			},
+			"dependencies": {
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
+			}
+		},
+		"lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"requires": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"magic-string": {
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"requires": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			}
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"micromatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.0.5"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"nanoid": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+		},
+		"node-html-parser": {
+			"version": "6.1.12",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.12.tgz",
+			"integrity": "sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==",
+			"requires": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
+		"node-releases": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.0.0"
+			}
+		},
+		"nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"requires": {
+				"boolbase": "^1.0.0"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
+		},
+		"p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
+			}
+		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+		},
+		"path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+		},
+		"picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+		},
+		"please-upgrade-node": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+			"dev": true,
+			"requires": {
+				"semver-compare": "^1.0.0"
+			}
+		},
+		"postcss": {
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"requires": {
+				"nanoid": "^3.3.6",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.2"
+			}
+		},
+		"preact": {
+			"version": "10.19.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.2.tgz",
+			"integrity": "sha512-UA9DX/OJwv6YwP9Vn7Ti/vF80XL+YA5H2l7BpCtUr3ya8LWHFzpiO5R+N7dN16ujpIxhekRFuOOF82bXX7K/lg=="
+		},
+		"preact-iso": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/preact-iso/-/preact-iso-2.3.2.tgz",
+			"integrity": "sha512-OU+6dzX1/qAyWfH4zKVqp/apNLfAr8yx4aBUVKyBWoOyPT08bNJk4o08KWIwyQyEkpayW5q+5+GAkYBSky8ndw==",
+			"dev": true,
+			"requires": {}
+		},
+		"preact-render-to-string": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.3.1.tgz",
+			"integrity": "sha512-NQ28WrjLtWY6lKDlTxnFpKHZdpjfF+oE6V4tZ0rTrunHrtZp6Dm0oFrcJalt/5PNeqJz4j1DuZDS0Y6rCBoqDA==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^3.8.0"
+			}
+		},
+		"prettier": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+			"integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"requires": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rollup": {
+			"version": "2.77.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+			"requires": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"rs-module-lexer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/rs-module-lexer/-/rs-module-lexer-2.1.1.tgz",
+			"integrity": "sha512-6F5a6PS3PJ/qZ0o+FKFcqABFBVsaMIOEMA4yBFyAwJnCpQ6a8CIk+ln3pRPrl0N2k6HgAupzXpQq4NuTVg5haQ==",
+			"requires": {
+				"@xn-sakina/rml-darwin-arm64": "2.1.1",
+				"@xn-sakina/rml-darwin-x64": "2.1.1",
+				"@xn-sakina/rml-linux-arm-gnueabihf": "2.1.1",
+				"@xn-sakina/rml-linux-arm64-gnu": "2.1.1",
+				"@xn-sakina/rml-linux-arm64-musl": "2.1.1",
+				"@xn-sakina/rml-linux-x64-gnu": "2.1.1",
+				"@xn-sakina/rml-linux-x64-musl": "2.1.1",
+				"@xn-sakina/rml-win32-arm64-msvc": "2.1.1",
+				"@xn-sakina/rml-win32-x64-msvc": "2.1.1"
+			}
+		},
+		"rxjs": {
+			"version": "6.6.6",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
+			"integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
+		"semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
+		},
+		"simple-git-hooks": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.9.0.tgz",
+			"integrity": "sha512-waSQ5paUQtyGC0ZxlHmcMmD9I1rRXauikBwX31bX58l5vTOhCEcBC5Bi+ZDkPXTjDnZAF8TbCqKBY+9+sVPScw==",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+		},
+		"source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"string-argv": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+			"dev": true
+		},
+		"string-width": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"stringify-object": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"dev": true,
+			"requires": {
+				"get-own-enumerable-property-symbols": "^3.0.0",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.0"
+			}
+		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
+		"ts-node": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			}
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
+		},
+		"type-fest": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"dev": true
+		},
+		"update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
+		},
+		"vite": {
+			"version": "2.9.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+			"integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+			"requires": {
+				"esbuild": "^0.14.27",
+				"fsevents": "~2.3.2",
+				"postcss": "^8.4.13",
+				"resolve": "^1.22.0",
+				"rollup": ">=2.59.0 <2.78.0"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+		},
+		"yaml": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.3.4",
 				"kolorist": "^1.8.0",
+				"node-html-parser": "^6.1.10",
 				"resolve": "^1.22.8"
 			},
 			"devDependencies": {
@@ -26,6 +27,7 @@
 				"@types/node": "^14.14.33",
 				"@types/resolve": "^1.20.1",
 				"lint-staged": "^10.5.4",
+				"magic-string": "^0.30.5",
 				"preact": "^10.19.2",
 				"preact-iso": "^2.3.2",
 				"preact-render-to-string": "^6.3.1",
@@ -39,8 +41,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
-				"magic-string": "^0.30.5",
-				"node-html-parser": "^6.1.10",
+				"magic-string": "0.*",
 				"vite": "2.x || 3.x || 4.x || 5.x"
 			}
 		},
@@ -753,8 +754,7 @@
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-			"peer": true
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -974,7 +974,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
 			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"peer": true,
 			"dependencies": {
 				"boolbase": "^1.0.0",
 				"css-what": "^6.1.0",
@@ -990,7 +989,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
 			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"peer": true,
 			"engines": {
 				"node": ">= 6"
 			},
@@ -1033,7 +1031,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"peer": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.2",
@@ -1052,14 +1049,12 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/fb55"
 				}
-			],
-			"peer": true
+			]
 		},
 		"node_modules/domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"peer": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0"
 			},
@@ -1074,7 +1069,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
 			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"peer": true,
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
@@ -1120,7 +1114,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"peer": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -1342,7 +1335,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"peer": true,
 			"bin": {
 				"he": "bin/he"
 			}
@@ -1634,7 +1626,7 @@
 			"version": "0.30.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
 			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
@@ -1714,7 +1706,6 @@
 			"version": "6.1.11",
 			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.11.tgz",
 			"integrity": "sha512-FAgwwZ6h0DSDWxfD0Iq1tsDcBCxdJB1nXpLPPxX8YyVWzbfCjKWEzaynF4gZZ/8hziUmp7ZSaKylcn0iKhufUQ==",
-			"peer": true,
 			"dependencies": {
 				"css-select": "^5.1.0",
 				"he": "1.2.0"
@@ -1750,7 +1741,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
 			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"peer": true,
 			"dependencies": {
 				"boolbase": "^1.0.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
 	"name": "@preact/preset-vite",
 	"version": "2.7.0",
-	"lockfileVersion": 2,
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
@@ -38,6 +38,8 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
+				"magic-string": "^0.30.5",
+				"node-html-parser": "^6.1.10",
 				"vite": "2.x || 3.x || 4.x || 5.x"
 			}
 		},
@@ -497,21 +499,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-			"cpu": [
-				"loong64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -762,6 +749,12 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"peer": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -976,6 +969,34 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1005,6 +1026,61 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"peer": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -1037,6 +1113,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/error-ex": {
@@ -1083,111 +1171,6 @@
 				"esbuild-windows-arm64": "0.14.54"
 			}
 		},
-		"node_modules/esbuild-android-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/esbuild-linux-64": {
 			"version": "0.14.54",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
@@ -1198,186 +1181,6 @@
 			"optional": true,
 			"os": [
 				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-			"cpu": [
-				"mips64el"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-			"cpu": [
-				"riscv64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-			"cpu": [
-				"s390x"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-			"cpu": [
-				"ia32"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -1460,19 +1263,6 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1545,6 +1335,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"peer": true,
+			"bin": {
+				"he": "bin/he"
 			}
 		},
 		"node_modules/human-signals": {
@@ -1830,6 +1629,18 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1898,6 +1709,16 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/node-html-parser": {
+			"version": "6.1.11",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.11.tgz",
+			"integrity": "sha512-FAgwwZ6h0DSDWxfD0Iq1tsDcBCxdJB1nXpLPPxX8YyVWzbfCjKWEzaynF4gZZ/8hziUmp7ZSaKylcn0iKhufUQ==",
+			"peer": true,
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.13",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -1922,6 +1743,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
 		"node_modules/once": {
@@ -2601,1736 +2434,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		}
-	},
-	"dependencies": {
-		"@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
-		"@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-			"requires": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"@babel/compat-data": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
-			"integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ=="
-		},
-		"@babel/core": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
-			"requires": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-module-transforms": "^7.23.0",
-				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.0",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0",
-				"convert-source-map": "^2.0.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.3",
-				"semver": "^6.3.1"
-			}
-		},
-		"@babel/generator": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
-			"requires": {
-				"@babel/types": "^7.23.0",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"jsesc": "^2.5.1"
-			}
-		},
-		"@babel/helper-annotate-as-pure": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
-		"@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
-			"requires": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
-				"lru-cache": "^5.1.1",
-				"semver": "^6.3.1"
-			}
-		},
-		"@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
-		},
-		"@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-			"requires": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
-			}
-		},
-		"@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-			"requires": {
-				"@babel/types": "^7.22.15"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
-			"requires": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-simple-access": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/helper-validator-identifier": "^7.22.20"
-			}
-		},
-		"@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg=="
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
-		"@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
-		},
-		"@babel/helper-validator-option": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA=="
-		},
-		"@babel/helpers": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
-			"requires": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
-		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.22.5"
-			}
-		},
-		"@babel/plugin-transform-react-jsx": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.15.tgz",
-			"integrity": "sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==",
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-jsx": "^7.22.5",
-				"@babel/types": "^7.22.15"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-development": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
-			"integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
-			"requires": {
-				"@babel/plugin-transform-react-jsx": "^7.22.5"
-			}
-		},
-		"@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-			"requires": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-			"requires": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.0",
-				"@babel/types": "^7.23.0",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0"
-			}
-		},
-		"@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
-			"requires": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@esbuild/linux-loong64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-			"optional": true
-		},
-		"@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
-		},
-		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.1.0",
-				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"@prefresh/babel-plugin": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.0.tgz",
-			"integrity": "sha512-joAwpkUDwo7ZqJnufXRGzUb+udk20RBgfA8oLPBh5aJH2LeStmV1luBfeJTztPdyCscC2j2SmZ/tVxFRMIxAEw=="
-		},
-		"@prefresh/core": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.2.tgz",
-			"integrity": "sha512-A/08vkaM1FogrCII5PZKCrygxSsc11obExBScm3JF1CryK2uDS3ZXeni7FeKCx1nYdUkj4UcJxzPzc1WliMzZA==",
-			"requires": {}
-		},
-		"@prefresh/utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.0.tgz",
-			"integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ=="
-		},
-		"@prefresh/vite": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.1.tgz",
-			"integrity": "sha512-vthWmEqu8TZFeyrBNc9YE5SiC3DVSzPgsOCp/WQ7FqdHpOIJi7Z8XvCK06rBPOtG4914S52MjG9Ls22eVAiuqQ==",
-			"requires": {
-				"@babel/core": "^7.22.1",
-				"@prefresh/babel-plugin": "0.5.0",
-				"@prefresh/core": "^1.5.1",
-				"@prefresh/utils": "^1.2.0",
-				"@rollup/pluginutils": "^4.2.1"
-			}
-		},
-		"@rollup/pluginutils": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-			"requires": {
-				"estree-walker": "^2.0.1",
-				"picomatch": "^2.2.2"
-			}
-		},
-		"@types/babel__core": {
-			"version": "7.1.14",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
-			"integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
-			"dev": true,
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"@types/babel__generator": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
-			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__template": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
-			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
-			"dev": true,
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__traverse": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
-			"integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.3.0"
-			}
-		},
-		"@types/debug": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
-			"dev": true
-		},
-		"@types/estree": {
-			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-			"dev": true
-		},
-		"@types/node": {
-			"version": "14.18.63",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-			"dev": true
-		},
-		"@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
-		},
-		"@types/resolve": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.1.tgz",
-			"integrity": "sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==",
-			"dev": true
-		},
-		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dev": true,
-			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			}
-		},
-		"ansi-colors": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
-		},
-		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.11.0"
-			}
-		},
-		"ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^2.0.1"
-			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
-		},
-		"astral-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true
-		},
-		"babel-plugin-transform-hook-names": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
-			"integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
-			"requires": {}
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
-			"requires": {
-				"fill-range": "^7.0.1"
-			}
-		},
-		"browserslist": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-			"requires": {
-				"caniuse-lite": "^1.0.30001541",
-				"electron-to-chromium": "^1.4.535",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.13"
-			}
-		},
-		"buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
-		},
-		"callsites": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
-		},
-		"caniuse-lite": {
-			"version": "1.0.30001547",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-			"integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA=="
-		},
-		"chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			}
-		},
-		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true
-		},
-		"cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "^3.1.0"
-			}
-		},
-		"cli-truncate": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-			"dev": true,
-			"requires": {
-				"slice-ansi": "^3.0.0",
-				"string-width": "^4.2.0"
-			}
-		},
-		"color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"requires": {
-				"color-name": "~1.1.4"
-			}
-		},
-		"color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"convert-source-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-		},
-		"cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-			"dev": true,
-			"requires": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			}
-		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
-		},
-		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
-			"requires": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			}
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"dedent": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
-		},
-		"electron-to-chromium": {
-			"version": "1.4.553",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.553.tgz",
-			"integrity": "sha512-HiRdtyKS2+VhiXvjhMvvxiMC33FJJqTA5EB2YHgFZW6v7HkK4Q9Ahv2V7O2ZPgAjw+MyCJVMQvigj13H8t+wvA=="
-		},
-		"emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
-		"enquirer": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "^4.1.1"
-			}
-		},
-		"error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
-			"requires": {
-				"is-arrayish": "^0.2.1"
-			}
-		},
-		"esbuild": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-			"requires": {
-				"@esbuild/linux-loong64": "0.14.54",
-				"esbuild-android-64": "0.14.54",
-				"esbuild-android-arm64": "0.14.54",
-				"esbuild-darwin-64": "0.14.54",
-				"esbuild-darwin-arm64": "0.14.54",
-				"esbuild-freebsd-64": "0.14.54",
-				"esbuild-freebsd-arm64": "0.14.54",
-				"esbuild-linux-32": "0.14.54",
-				"esbuild-linux-64": "0.14.54",
-				"esbuild-linux-arm": "0.14.54",
-				"esbuild-linux-arm64": "0.14.54",
-				"esbuild-linux-mips64le": "0.14.54",
-				"esbuild-linux-ppc64le": "0.14.54",
-				"esbuild-linux-riscv64": "0.14.54",
-				"esbuild-linux-s390x": "0.14.54",
-				"esbuild-netbsd-64": "0.14.54",
-				"esbuild-openbsd-64": "0.14.54",
-				"esbuild-sunos-64": "0.14.54",
-				"esbuild-windows-32": "0.14.54",
-				"esbuild-windows-64": "0.14.54",
-				"esbuild-windows-arm64": "0.14.54"
-			}
-		},
-		"esbuild-android-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-			"optional": true
-		},
-		"escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-		},
-		"execa": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.0",
-				"get-stream": "^5.0.0",
-				"human-signals": "^1.1.1",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.0",
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2",
-				"strip-final-newline": "^2.0.0"
-			}
-		},
-		"figures": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
-			}
-		},
-		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"optional": true
-		},
-		"gensync": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
-		},
-		"get-own-enumerable-property-symbols": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
-			"dev": true
-		},
-		"get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
-		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-		},
-		"has": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ=="
-		},
-		"has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
-		},
-		"human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-			"dev": true
-		},
-		"import-fresh": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
-			"requires": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
-			}
-		},
-		"indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"dev": true
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
-		},
-		"is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
-		},
-		"is-core-module": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-			"integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
-		"is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true
-		},
-		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-			"dev": true
-		},
-		"is-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-			"dev": true
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-		},
-		"json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
-		},
-		"json5": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
-		},
-		"kolorist": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
-		},
-		"lines-and-columns": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
-		},
-		"lint-staged": {
-			"version": "10.5.4",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
-			"integrity": "sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.1.0",
-				"cli-truncate": "^2.1.0",
-				"commander": "^6.2.0",
-				"cosmiconfig": "^7.0.0",
-				"debug": "^4.2.0",
-				"dedent": "^0.7.0",
-				"enquirer": "^2.3.6",
-				"execa": "^4.1.0",
-				"listr2": "^3.2.2",
-				"log-symbols": "^4.0.0",
-				"micromatch": "^4.0.2",
-				"normalize-path": "^3.0.0",
-				"please-upgrade-node": "^3.2.0",
-				"string-argv": "0.3.1",
-				"stringify-object": "^3.3.0"
-			}
-		},
-		"listr2": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.4.3.tgz",
-			"integrity": "sha512-wZmkzNiuinOfwrGqAwTCcPw6aKQGTAMGXwG5xeU1WpDjJNeBA35jGBeWxR3OF+R6Yl5Y3dRG+3vE8t6PDcSNHA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.1.0",
-				"cli-truncate": "^2.1.0",
-				"figures": "^3.2.0",
-				"indent-string": "^4.0.0",
-				"log-update": "^4.0.0",
-				"p-map": "^4.0.0",
-				"rxjs": "^6.6.6",
-				"through": "^2.3.8",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.0.0"
-			}
-		},
-		"log-update": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-			"integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^4.3.0",
-				"cli-cursor": "^3.1.0",
-				"slice-ansi": "^4.0.0",
-				"wrap-ansi": "^6.2.0"
-			},
-			"dependencies": {
-				"slice-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"astral-regex": "^2.0.0",
-						"is-fullwidth-code-point": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				}
-			}
-		},
-		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"requires": {
-				"yallist": "^3.0.2"
-			}
-		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
-		},
-		"micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-			"dev": true,
-			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
-			}
-		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
-		"minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
-		},
-		"node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
-		},
-		"normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"requires": {
-				"path-key": "^3.0.0"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"requires": {
-				"mimic-fn": "^2.1.0"
-			}
-		},
-		"p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"dev": true,
-			"requires": {
-				"aggregate-error": "^3.0.0"
-			}
-		},
-		"parent-module": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
-			"requires": {
-				"callsites": "^3.0.0"
-			}
-		},
-		"parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
-		"path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
-		},
-		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-		},
-		"picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-		},
-		"please-upgrade-node": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-			"dev": true,
-			"requires": {
-				"semver-compare": "^1.0.0"
-			}
-		},
-		"postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-			"requires": {
-				"nanoid": "^3.3.6",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
-			}
-		},
-		"preact": {
-			"version": "10.19.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.2.tgz",
-			"integrity": "sha512-UA9DX/OJwv6YwP9Vn7Ti/vF80XL+YA5H2l7BpCtUr3ya8LWHFzpiO5R+N7dN16ujpIxhekRFuOOF82bXX7K/lg=="
-		},
-		"preact-iso": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/preact-iso/-/preact-iso-2.3.2.tgz",
-			"integrity": "sha512-OU+6dzX1/qAyWfH4zKVqp/apNLfAr8yx4aBUVKyBWoOyPT08bNJk4o08KWIwyQyEkpayW5q+5+GAkYBSky8ndw==",
-			"dev": true,
-			"requires": {}
-		},
-		"preact-render-to-string": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.3.1.tgz",
-			"integrity": "sha512-NQ28WrjLtWY6lKDlTxnFpKHZdpjfF+oE6V4tZ0rTrunHrtZp6Dm0oFrcJalt/5PNeqJz4j1DuZDS0Y6rCBoqDA==",
-			"dev": true,
-			"requires": {
-				"pretty-format": "^3.8.0"
-			}
-		},
-		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-			"dev": true
-		},
-		"pretty-format": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-			"integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-			"dev": true
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"requires": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			}
-		},
-		"resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
-		},
-		"restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"requires": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
-		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"rollup": {
-			"version": "2.77.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
-			"requires": {
-				"fsevents": "~2.3.2"
-			}
-		},
-		"rxjs": {
-			"version": "6.6.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-			"integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
-		},
-		"semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
-		},
-		"semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-			"dev": true
-		},
-		"shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
-			"requires": {
-				"shebang-regex": "^3.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true
-		},
-		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
-		},
-		"simple-git-hooks": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.9.0.tgz",
-			"integrity": "sha512-waSQ5paUQtyGC0ZxlHmcMmD9I1rRXauikBwX31bX58l5vTOhCEcBC5Bi+ZDkPXTjDnZAF8TbCqKBY+9+sVPScw==",
-			"dev": true
-		},
-		"slice-ansi": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			}
-		},
-		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true
-		},
-		"source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
-		},
-		"source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"string-argv": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-			"dev": true
-		},
-		"string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-			"dev": true,
-			"requires": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			}
-		},
-		"stringify-object": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-			"dev": true,
-			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^5.0.0"
-			}
-		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^4.0.0"
-			}
-		},
-		"supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-		},
-		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^7.0.0"
-			}
-		},
-		"ts-node": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-			"dev": true,
-			"requires": {
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.17",
-				"yn": "3.1.1"
-			}
-		},
-		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
-		},
-		"type-fest": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-			"dev": true
-		},
-		"typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true
-		},
-		"update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-			"requires": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
-			}
-		},
-		"vite": {
-			"version": "2.9.16",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-			"integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
-			"requires": {
-				"esbuild": "^0.14.27",
-				"fsevents": "~2.3.2",
-				"postcss": "^8.4.13",
-				"resolve": "^1.22.0",
-				"rollup": ">=2.59.0 <2.78.0"
-			}
-		},
-		"which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
-		"wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-		},
-		"yaml": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"debug": "^4.3.4",
 		"kolorist": "^1.8.0",
 		"node-html-parser": "^6.1.10",
-		"resolve": "^1.22.8"
+		"resolve": "^1.22.8",
+		"rs-module-lexer": "^2.1.1"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.4",
 		"kolorist": "^1.8.0",
+		"magic-string": "^0.30.5",
+		"node-html-parser": "^6.1.10",
 		"resolve": "^1.22.8"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"magic-string": "^0.30.5",
-		"node-html-parser": "^6.1.10",
 		"vite": "2.x || 3.x || 4.x || 5.x"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.4",
 		"kolorist": "^1.8.0",
+		"magic-string": "0.30.5",
 		"node-html-parser": "^6.1.10",
 		"resolve": "^1.22.8",
 		"rs-module-lexer": "^2.1.1"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"magic-string": "0.x",
 		"vite": "2.x || 3.x || 4.x || 5.x"
 	},
 	"devDependencies": {
@@ -57,7 +57,6 @@
 		"@types/node": "^14.14.33",
 		"@types/resolve": "^1.20.1",
 		"lint-staged": "^10.5.4",
-		"magic-string": "^0.30.5",
 		"preact": "^10.19.2",
 		"preact-iso": "^2.3.2",
 		"preact-render-to-string": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.3.4",
 		"kolorist": "^1.8.0",
-		"magic-string": "^0.30.5",
 		"node-html-parser": "^6.1.10",
 		"resolve": "^1.22.8"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
+		"magic-string": "0.*",
 		"vite": "2.x || 3.x || 4.x || 5.x"
 	},
 	"devDependencies": {
@@ -56,6 +56,7 @@
 		"@types/node": "^14.14.33",
 		"@types/resolve": "^1.20.1",
 		"lint-staged": "^10.5.4",
+		"magic-string": "^0.30.5",
 		"preact": "^10.19.2",
 		"preact-iso": "^2.3.2",
 		"preact-render-to-string": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"magic-string": "0.*",
+		"magic-string": "0.x",
 		"vite": "2.x || 3.x || 4.x || 5.x"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"preact-render-to-string": "^6.3.1",
 		"prettier": "^2.2.1",
 		"rimraf": "^3.0.2",
+		"rollup": "^2.77.3",
 		"simple-git-hooks": "^2.0.2",
 		"ts-node": "^9.1.1",
 		"typescript": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
+		"magic-string": "^0.30.5",
+		"node-html-parser": "^6.1.10",
 		"vite": "2.x || 3.x || 4.x || 5.x"
 	},
 	"devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export interface PreactPluginOptions {
 		/**
 		 * Additional routes that should be prerendered
 		 */
-		additionalRoutes?: string[];
+		additionalPrerenderRoutes?: string[];
 	};
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,10 @@ export interface PreactPluginOptions {
 		 */
 		prerenderScript?: string;
 		/**
+		 * Query selector for specifying where to insert prerender result in your HTML template
+		 */
+		renderTarget?: string;
+		/**
 		 * Additional routes that should be prerendered
 		 */
 		additionalPrerenderRoutes?: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type { TransformOptions } from "@babel/core";
 import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools.js";
 import { createFilter, parseId } from "./utils.js";
+import { PrerenderPlugin } from "./prerender.js";
 import { transformAsync } from "@babel/core";
 
 export type BabelOptions = Omit<
@@ -44,6 +45,24 @@ export interface PreactPluginOptions {
 	reactAliasesEnabled?: boolean;
 
 	/**
+	 * Prerender plugin options
+	 */
+	prerender?: {
+		/**
+		 * Whether to prerender your app on build
+		 */
+		enabled: boolean;
+		/**
+		 * Absolute path to script containing an exported `prerender()` function
+		 */
+		prerenderScript?: string;
+		/**
+		 * Additional routes that should be prerendered
+		 */
+		additionalRoutes?: string[];
+	};
+
+	/**
 	 * RegExp or glob to match files to be transformed
 	 */
 	include?: FilterPattern;
@@ -78,6 +97,7 @@ function preactPlugin({
 	devToolsEnabled,
 	prefreshEnabled,
 	reactAliasesEnabled,
+	prerender,
 	include,
 	exclude,
 	babel,
@@ -110,6 +130,7 @@ function preactPlugin({
 	devToolsEnabled = devToolsEnabled ?? true;
 	prefreshEnabled = prefreshEnabled ?? true;
 	reactAliasesEnabled = reactAliasesEnabled ?? true;
+	prerender = prerender ?? { enabled: false };
 
 	const jsxPlugin: Plugin = {
 		name: "vite:preact-jsx",
@@ -221,6 +242,7 @@ function preactPlugin({
 		...(prefreshEnabled
 			? [prefresh({ include, exclude, parserPlugins: baseParserOptions })]
 			: []),
+		...(prerender.enabled ? [PrerenderPlugin(prerender)] : []),
 	];
 }
 

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -1,0 +1,261 @@
+import path from "node:path";
+import os from "node:os";
+import { promises as fs } from "node:fs";
+import MagicString from "magic-string";
+import { parse } from "node-html-parser";
+
+function enc(str) {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.prerenderScript=index] - Path to the script that exports a `prerender` function
+ * @returns {import('vite').Plugin}
+ */
+export function HeadlessPrerenderPlugin({ prerenderScript } = {}) {
+	const preloadHelperId = "\0vite/preload-helper";
+
+	prerenderScript = prerenderScript ?? "index";
+
+	/**
+	 * @param {import('vite').Rollup.InputOptions} opts
+	 */
+	const getEntryScript = async opts => {
+		const entryHtml =
+			typeof opts.input === "string"
+				? opts.input
+				: Array.isArray(opts.input)
+				? opts.input.find(i => /html$/.test(i))
+				: Object.values(opts.input).find(i => /html$/.test(i));
+
+		const htmlDoc = parse(await fs.readFile(entryHtml, "utf-8"));
+
+		const scripts = htmlDoc
+			.getElementsByTagName("script")
+			.map(s => s.getAttribute("src"))
+			.filter(src => !/^https:/.test(src));
+
+		const entryScript = scripts.find(src => {
+			if (prerenderScript === "index") {
+				if (/index\.[tj]sx?$/.test(src)) return true;
+			} else if (src.endsWith(prerenderScript)) return true;
+			return false;
+		});
+
+		if (!entryScript) {
+			throw new Error(`Unable to detect entrypoint in your index.html.`);
+		}
+
+		return path.join(process.cwd(), entryScript);
+	};
+
+	return {
+		name: "headless-prerender",
+		apply: "build",
+		enforce: "post",
+		async options(opts) {
+			const entryScript = await getEntryScript(opts);
+
+			opts.input =
+				typeof opts.input === "string"
+					? [opts.input, entryScript]
+					: Array.isArray(opts.input)
+					? [...opts.input, entryScript]
+					: { ...opts.input, prerenderEntry: entryScript };
+			opts.preserveEntrySignatures = "allow-extension";
+		},
+		transform(code, id) {
+			// Injects a window check into Vite's preload helper, instantly resolving
+			// the module rather than attempting to add a <link> to the document.
+			//
+			// TODO: See if we can make this less brittle
+			if (id === preloadHelperId) {
+				const s = new MagicString(code);
+				s.replace(
+					`const links = document.getElementsByTagName('link');`,
+					`if (typeof window === 'undefined') return new Promise(r => r()).then(() => baseModule());
+                         const links = document.getElementsByTagName('link');`,
+				);
+				return {
+					code: s.toString(),
+					map: s.generateMap({ hires: true }),
+				};
+			}
+		},
+		async generateBundle(_opts, bundle) {
+			globalThis.location = /** @type {object} */ ({});
+			globalThis.self = /** @type {any} */ (globalThis);
+
+			// Grab the generated HTML file, which we'll use as a template:
+			const tpl = bundle["index.html"].source;
+			let htmlDoc = parse(tpl);
+
+			const tmpDir = await fs.mkdtemp(
+				path.join(os.tmpdir(), "headless-prerender-"),
+			);
+			await fs.writeFile(
+				path.join(tmpDir, "package.json"),
+				JSON.stringify({ type: "module" }),
+			);
+
+			let entryScript;
+			const outputs = Object.keys(bundle);
+			for (const output of outputs) {
+				if (!/\.js$/.test(output)) continue;
+
+				await fs.writeFile(
+					path.join(tmpDir, path.basename(output)),
+					bundle[output].code,
+				);
+
+				if (bundle[output].exports?.includes("prerender")) {
+					entryScript = bundle[output];
+					break;
+				}
+			}
+
+			/** @typedef {{ type: string, props: Record<string, string>, children?: string } | string | null} HeadElement */
+
+			/**
+			 * @type {{ lang: string, title: string, elements: Set<HeadElement>}}
+			 */
+			let head = { lang: "", title: "", elements: new Set() };
+
+			const m = await import(
+				`file://${path.join(tmpDir, path.basename(entryScript.fileName))}`
+			);
+			const prerender = m.prerender;
+
+			if (typeof prerender !== "function") {
+				// TODO: Figure out better error message / handling here
+				console.log("Detected `prerender` export, but it is not a function.");
+			}
+
+			/**
+			 * @param {HeadElement|HeadElement[]|Set<HeadElement>} element
+			 * @returns {string} html
+			 */
+			function serializeElement(element) {
+				if (element == null) return "";
+				if (typeof element !== "object") return String(element);
+				if (Array.isArray(element))
+					return element.map(serializeElement).join("");
+				const type = element.type;
+				let s = `<${type}`;
+				const props = element.props || {};
+				let children = element.children;
+				for (const prop of Object.keys(props).sort()) {
+					const value = props[prop];
+					// Filter out empty values:
+					if (value == null) continue;
+					if (prop === "children" || prop === "textContent") children = value;
+					else s += ` ${prop}="${enc(value)}"`;
+				}
+				s += ">";
+				if (!/link|meta|base/.test(type)) {
+					if (children) s += serializeElement(children);
+					s += `</${type}>`;
+				}
+				return s;
+			}
+
+			// We start by pre-rendering the home page.
+			// Links discovered during pre-rendering get pushed into the list of routes.
+			const seen = new Set(["/"]);
+
+			/** @typedef {{ url: string, _discoveredBy?: PrerenderedRoute }} PrerenderedRoute */
+			/** @type {PrerenderedRoute[]} */
+			let routes = [...seen].map(link => ({ url: link }));
+
+			for (const route of routes) {
+				if (!route.url) continue;
+
+				const outDir = route.url.replace(/(^\/|\/$)/g, "");
+				const assetName = path.join(
+					outDir,
+					outDir.endsWith(".html") ? "" : "index.html",
+				);
+
+				// Update `location` to current URL so routers can use things like location.pathname:
+				const u = new URL(route.url, "http://localhost");
+				for (let i in u) {
+					try {
+						globalThis.location[i] = String(u[i]);
+					} catch {}
+				}
+
+				const result = await prerender({ ssr: true, url: route.url, route });
+				if (result == null) continue;
+
+				// Reset HTML doc & head data
+				htmlDoc = parse(tpl);
+				head = { lang: "", title: "", elements: new Set() };
+
+				// Add any discovered links to the list of routes to pre-render:
+				if (result.links) {
+					for (let url of result.links) {
+						const parsed = new URL(url, "http://localhost");
+						url = parsed.pathname;
+						// ignore external links and one's we've already picked up
+						if (seen.has(url) || parsed.origin !== "http://localhost") continue;
+						seen.add(url);
+						routes.push({ url, _discoveredBy: route });
+					}
+				}
+
+				let body;
+				if (result && typeof result === "object") {
+					if (result.html) body = result.html;
+					if (result.head) {
+						head = result.head;
+					}
+				} else {
+					body = result;
+				}
+
+				const htmlHead = htmlDoc.querySelector("head");
+
+				if (head.title) {
+					const htmlTitle = htmlHead.querySelector("title");
+					htmlTitle
+						? htmlTitle.set_content(enc(head.title))
+						: htmlHead.insertAdjacentHTML(
+								"afterbegin",
+								`<title>${enc(head.title)}</title>`,
+						  );
+				}
+
+				if (head.lang) {
+					htmlDoc.querySelector("html").setAttribute("lang", enc(head.lang));
+				}
+
+				if (head.elements) {
+					// Inject HTML links at the end of <head> for any stylesheets injected during rendering of the page:
+					htmlHead.insertAdjacentHTML(
+						"beforeend",
+						Array.from(
+							new Set(Array.from(head.elements).map(serializeElement)),
+						).join(""),
+					);
+				}
+
+				// Inject pre-rendered HTML into the start of <body>:
+				htmlDoc.querySelector("body").insertAdjacentHTML("afterbegin", body);
+
+				// Add generated HTML to compilation:
+				if (route.url === "/") bundle["index.html"].source = htmlDoc.toString();
+				else
+					this.emitFile({
+						type: "asset",
+						fileName: assetName,
+						source: htmlDoc.toString(),
+					});
+			}
+		},
+	};
+}

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -54,12 +54,13 @@ export function PrerenderPlugin({
 	const guessPrerenderScriptFromHTML = async (
 		input: string | string[] | { [entryAlias: string]: string },
 	) => {
+		// prettier-ignore
 		const entryHtml =
 			typeof input === "string"
 				? input
 				: Array.isArray(input)
-				? input.find(i => /html$/.test(i))
-				: Object.values(input).find(i => /html$/.test(i));
+					? input.find(i => /html$/.test(i))
+					: Object.values(input).find(i => /html$/.test(i));
 
 		if (!entryHtml) throw new Error("Unable to detect entry HTML file.");
 
@@ -88,12 +89,13 @@ export function PrerenderPlugin({
 				prerenderScript = await guessPrerenderScriptFromHTML(opts.input);
 			}
 
+			// prettier-ignore
 			opts.input =
 				typeof opts.input === "string"
 					? [opts.input, prerenderScript]
 					: Array.isArray(opts.input)
-					? [...opts.input, prerenderScript]
-					: { ...opts.input, prerenderEntry: prerenderScript };
+						? [...opts.input, prerenderScript]
+						: { ...opts.input, prerenderEntry: prerenderScript };
 			opts.preserveEntrySignatures = "allow-extension";
 		},
 		// Injects a window check into Vite's preload helper, instantly resolving

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -46,7 +46,7 @@ function serializeElement(
 	let s = `<${type}`;
 	const props = element.props || {};
 	let children = element.children;
-	for (const prop of Object.keys(props).sort()) {
+	for (const prop of Object.keys(props)) {
 		const value = props[prop];
 		// Filter out empty values:
 		if (value == null) continue;

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -153,10 +153,18 @@ export function PrerenderPlugin({
 			// Vite keeps changing up the ID, best we can do for cross-version
 			// compat is an `includes`
 			if (id.includes(preloadHelperId)) {
+				// Through v5.0.4
+				// https://github.com/vitejs/vite/blob/b93dfe3e08f56cafe2e549efd80285a12a3dc2f0/packages/vite/src/node/plugins/importAnalysisBuild.ts#L95-L98
 				const s = new MagicString(code);
 				s.replace(
-					`deps.length === 0`,
-					`deps.length === 0 || typeof window === 'undefined'`,
+					`if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {`,
+					`if (!__VITE_IS_MODERN__ || !deps || deps.length === 0 || typeof window === 'undefined') {`,
+				);
+				// 5.0.5+
+				// https://github.com/vitejs/vite/blob/c902545476a4e7ba044c35b568e73683758178a3/packages/vite/src/node/plugins/importAnalysisBuild.ts#L93
+				s.replace(
+					`if (__VITE_IS_MODERN__ && deps && deps.length > 0) {`,
+					`if (__VITE_IS_MODERN__ && deps && deps.length > 0 && typeof window !== 'undefined') {`,
 				);
 				return {
 					code: s.toString(),

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -222,7 +222,7 @@ export function PrerenderPlugin({
 
 			let prerenderEntry;
 			for (const output of Object.keys(bundle)) {
-				if (!/\.js$/.test(output)) continue;
+				if (!/\.js$/.test(output) || bundle[output].type !== "chunk") continue;
 
 				await fs.writeFile(
 					path.join(tmpDir, path.basename(output)),

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -5,7 +5,7 @@ import { promises as fs } from "node:fs";
 
 import MagicString from "magic-string";
 import { parse as htmlParse } from "node-html-parser";
-import { parseAsync as moduleLexerParseAsync } from "rs-module-lexer";
+import rsModuleLexer from "rs-module-lexer";
 
 import type { Plugin, ResolvedConfig } from "vite";
 
@@ -101,7 +101,7 @@ export function PrerenderPlugin({
 		if (scripts.length === 0)
 			throw new Error("No local scripts found in entry HTML");
 
-		const { output } = await moduleLexerParseAsync({
+		const { output } = await rsModuleLexer.parseAsync({
 			input: await Promise.all(
 				scripts.map(async script => ({
 					filename: script,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -253,9 +253,9 @@ export function PrerenderPlugin({
 
 					This ${
 						isReferenceError ? "is most likely" : "could be"
-					} caused by using DOM/Web APIs
-					which are not available to the prerendering process which runs in Node. Consider wrapping
-					the offending code in a window check like so:
+					} caused by using DOM/Web APIs which are not available
+					available to the prerendering process which runs in Node. Consider
+					wrapping the offending code in a window check like so:
 
 					if (typeof window !== "undefined") {
 						// do something in browsers only

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -119,7 +119,8 @@ export function PrerenderPlugin({
 			}
 		}
 
-		if (!entryScript) throw new Error("Unable to detect local entry script");
+		if (!entryScript)
+			throw new Error("Unable to detect prerender entry script");
 
 		return path.join(viteConfig.root, entryScript);
 	};

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -329,8 +329,15 @@ export function PrerenderPlugin({
 					}
 				}
 
-				// Inject pre-rendered HTML into the start of <body>:
-				htmlDoc.querySelector("body")?.insertAdjacentHTML("afterbegin", body);
+				result.selector ??= "body";
+				const target = htmlDoc.querySelector(result.selector);
+				if (!target)
+					throw new Error(
+						result.selector == "body"
+							? "No prerender selector was specified and <body> does not exist in input HTML template"
+							: `Unable to detect prerender selector "${result.selector}" in input HTML template`,
+					);
+				target.insertAdjacentHTML("afterbegin", body);
 
 				// Add generated HTML to compilation:
 				if (route.url === "/")

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import os from "node:os";
 
 import { promises as fs } from "node:fs";
 
@@ -203,17 +202,26 @@ export function PrerenderPlugin({
 
 			// Create a tmp dir to allow importing & consuming the built modules,
 			// before Rollup writes them to the disk
-			const tmpDir = await fs.mkdtemp(
-				path.join(os.tmpdir(), "headless-prerender-"),
+			const tmpDir = path.join(
+				viteConfig.root,
+				"node_modules",
+				"@preact/preset-vite",
+				"headless-prerender",
 			);
+			try {
+				await fs.rm(tmpDir, { recursive: true });
+			} catch (e: any) {
+				if (e.code !== "ENOENT") throw e;
+			}
+			await fs.mkdir(tmpDir, { recursive: true });
+
 			await fs.writeFile(
 				path.join(tmpDir, "package.json"),
 				JSON.stringify({ type: "module" }),
 			);
 
 			let prerenderEntry;
-			const outputs = Object.keys(bundle);
-			for (const output of outputs) {
+			for (const output of Object.keys(bundle)) {
 				if (!/\.js$/.test(output)) continue;
 
 				await fs.writeFile(

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -129,7 +129,9 @@ export function PrerenderPlugin({
 		// Injects a window check into Vite's preload helper, instantly resolving
 		// the module rather than attempting to add a <link> to the document.
 		transform(code, id) {
-			if (id.endsWith(preloadHelperId)) {
+			// Vite keeps changing up the ID, best we can do for cross-version
+			// compat is an `includes`
+			if (id.includes(preloadHelperId)) {
 				const s = new MagicString(code);
 				s.replace(
 					`deps.length === 0`,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -64,16 +64,19 @@ function serializeElement(
 
 interface PrerenderPluginOptions {
 	prerenderScript?: string;
+	renderTarget?: string;
 	additionalPrerenderRoutes?: string[];
 }
 
 export function PrerenderPlugin({
 	prerenderScript,
+	renderTarget,
 	additionalPrerenderRoutes,
 }: PrerenderPluginOptions = {}): Plugin {
 	const preloadHelperId = "vite/preload-helper";
 	let viteConfig = {} as ResolvedConfig;
 
+	renderTarget ||= "body";
 	additionalPrerenderRoutes ||= [];
 
 	/**
@@ -349,12 +352,11 @@ export function PrerenderPlugin({
 					}
 				}
 
-				result.renderTarget ??= "body";
-				const target = htmlDoc.querySelector(result.renderTarget);
+				const target = htmlDoc.querySelector(renderTarget!);
 				if (!target)
 					throw new Error(
 						result.renderTarget == "body"
-							? "No prerender renderTarget was specified and <body> does not exist in input HTML template"
+							? "`renderTarget` was not specified in plugin options and <body> does not exist in input HTML template"
 							: `Unable to detect prerender renderTarget "${result.selector}" in input HTML template`,
 					);
 				target.insertAdjacentHTML("afterbegin", body);

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -324,7 +324,7 @@ export function PrerenderPlugin({
 							"beforeend",
 							Array.from(
 								new Set(Array.from(head.elements).map(serializeElement)),
-							).join(""),
+							).join("\n"),
 						);
 					}
 				}

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -179,9 +179,7 @@ export function PrerenderPlugin({
 			let head: Head = { lang: "", title: "", elements: new Set() };
 
 			if (!prerenderEntry) {
-				// TODO: Figure out better error message / handling here
-				console.log("Cannot detect module with `prerender` export");
-				return;
+				this.error("Cannot detect module with `prerender` export");
 			}
 
 			const m = await import(
@@ -190,9 +188,7 @@ export function PrerenderPlugin({
 			const prerender = m.prerender;
 
 			if (typeof prerender !== "function") {
-				// TODO: Figure out better error message / handling here
-				console.log("Detected `prerender` export, but it is not a function.");
-				return;
+				this.error("Detected `prerender` export, but it is not a function");
 			}
 
 			// We start by pre-rendering the home page.

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -354,7 +354,7 @@ export function PrerenderPlugin({
 
 				const target = htmlDoc.querySelector(renderTarget!);
 				if (!target)
-					throw new Error(
+					this.error(
 						result.renderTarget == "body"
 							? "`renderTarget` was not specified in plugin options and <body> does not exist in input HTML template"
 							: `Unable to detect prerender renderTarget "${result.selector}" in input HTML template`,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -125,7 +125,7 @@ export function PrerenderPlugin({
 	};
 
 	return {
-		name: "headless-prerender",
+		name: "preact:prerender",
 		apply: "build",
 		enforce: "post",
 		configResolved(config) {
@@ -233,12 +233,11 @@ export function PrerenderPlugin({
 					prerenderEntry = bundle[output];
 				}
 			}
-
-			let head: Head = { lang: "", title: "", elements: new Set() };
-
 			if (!prerenderEntry) {
 				this.error("Cannot detect module with `prerender` export");
 			}
+
+			let head: Head = { lang: "", title: "", elements: new Set() };
 
 			const m = await import(
 				`file://${path.join(tmpDir, path.basename(prerenderEntry.fileName))}`
@@ -266,7 +265,7 @@ export function PrerenderPlugin({
 
 				// Update `location` to current URL so routers can use things like `location.pathname`
 				const u = new URL(route.url, "http://localhost");
-				for (let i in u) {
+				for (const i in u) {
 					try {
 						// @ts-ignore
 						globalThis.location[i] = String(u[i]);

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -143,7 +143,6 @@ export function PrerenderPlugin({
 
 				if (bundle[output].exports?.includes("prerender")) {
 					prerenderEntry = bundle[output];
-					break;
 				}
 			}
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -329,13 +329,13 @@ export function PrerenderPlugin({
 					}
 				}
 
-				result.selector ??= "body";
-				const target = htmlDoc.querySelector(result.selector);
+				result.renderTarget ??= "body";
+				const target = htmlDoc.querySelector(result.renderTarget);
 				if (!target)
 					throw new Error(
-						result.selector == "body"
-							? "No prerender selector was specified and <body> does not exist in input HTML template"
-							: `Unable to detect prerender selector "${result.selector}" in input HTML template`,
+						result.renderTarget == "body"
+							? "No prerender renderTarget was specified and <body> does not exist in input HTML template"
+							: `Unable to detect prerender renderTarget "${result.selector}" in input HTML template`,
 					);
 				target.insertAdjacentHTML("afterbegin", body);
 

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -16,5 +16,8 @@ test("builds demo successfully", async () => {
 	);
 
 	const outputHtml = await fs.readFile(dir("demo/dist/index.html"), "utf-8");
-	assert.match(outputHtml, /Hello from Preact/);
+	assert.match(outputHtml, /lang="en"/);                        // Checks head.lang
+	assert.match(outputHtml, /Prerendered Preact App/);           // Checks head.title
+	assert.match(outputHtml, /This is a prerendered Preact app/); // Checks head.elements
+	assert.match(outputHtml, /Hello from Preact/);                // Checks body
 });

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -16,10 +16,13 @@ test("builds demo successfully", async () => {
 	);
 
 	const outputHtml = await fs.readFile(dir("demo/dist/index.html"), "utf-8");
-	assert.match(outputHtml, /lang="en"/);                        // Checks head.lang
-	assert.match(outputHtml, /Prerendered Preact App/);           // Checks head.title
-	assert.match(outputHtml, /This is a prerendered Preact app/); // Checks head.elements
-	assert.match(outputHtml, /Hello from Preact/);                // Checks body
+	assert.match(outputHtml, /Get Started building Vite-powered Preact Apps/);
 
+	// Head API
+	assert.match(outputHtml, /<html lang="en">/);
+	assert.match(outputHtml, /<title>Prerendered Preact App<\/title>/);
+	assert.match(outputHtml, /<meta name="description" content="This is a prerendered Preact app">/);
+
+	// `additionalPrerenderRoutes` config option
 	assert.doesNotThrow(async () => await fs.access(dir("demo/dist/404/index.html")));
 });

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -20,4 +20,6 @@ test("builds demo successfully", async () => {
 	assert.match(outputHtml, /Prerendered Preact App/);           // Checks head.title
 	assert.match(outputHtml, /This is a prerendered Preact app/); // Checks head.elements
 	assert.match(outputHtml, /Hello from Preact/);                // Checks body
+
+	assert.doesNotThrow(async () => await fs.access(dir("demo/dist/404/index.html")));
 });

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -23,6 +23,9 @@ test("builds demo successfully", async () => {
 	assert.match(outputHtml, /<title>Prerendered Preact App<\/title>/);
 	assert.match(outputHtml, /<meta name="description" content="This is a prerendered Preact app">/);
 
+	// Local Fetch
+	assert.match(outputHtml, /Local fetch works/);
+
 	// `additionalPrerenderRoutes` config option
 	assert.doesNotThrow(async () => await fs.access(dir("demo/dist/404/index.html")));
 });

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { test } from "node:test";
 import { promisify } from "node:util";
+import { promises as fs } from "node:fs";
+import assert from "node:assert";
 import { dir } from "./util.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -12,4 +14,7 @@ test("builds demo successfully", async () => {
 		[dir("node_modules/vite/bin/vite.js"), "build"],
 		{ cwd: dir("demo"), encoding: "utf8" },
 	);
+
+	const outputHtml = await fs.readFile(dir("demo/dist/index.html"), "utf-8");
+	assert.match(outputHtml, /Hello from Preact/);
 });


### PR DESCRIPTION
Largely mimics WMR's setup, as that was pretty slick, with a few minor changes:

- Can prerender into any template element, doesn't require `document.body`
- Will search for `prerender()` function in any script listed in input HTML doc, doesn't require a certain placement
  - User can specify a prerender script through the plugin options instead, if they prefer/need to
- Regex is fun, but switched off the HTML regex shenanigans for a real html parser. I'm a buzzkill, I know.

Patches for Vite's preloader were all that was needed to get the bundles working in Node. [I've asked if they'd be willing to implement this upstream](https://github.com/vitejs/vite/issues/15369), but we'll see.