### PR TITLE
chore: Add demo `tsconfig.json`, prettifies `.json` on commit, add `preact` as a devDep

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"noEmit": true,
+		"allowJs": true,
+		"checkJs": true,
+
+		/* Preact Config */
+		"jsx": "react-jsx",
+		"jsxImportSource": "preact"
+	},
+	"include": ["node_modules/vite/client.d.ts", "**/*"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@types/node": "^14.14.33",
 				"@types/resolve": "^1.20.1",
 				"lint-staged": "^10.5.4",
+				"preact": "^10.19.2",
 				"prettier": "^2.2.1",
 				"rimraf": "^3.0.2",
 				"simple-git-hooks": "^2.0.2",
@@ -2075,10 +2076,9 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.18.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.18.1.tgz",
-			"integrity": "sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==",
-			"peer": true,
+			"version": "10.19.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.2.tgz",
+			"integrity": "sha512-UA9DX/OJwv6YwP9Vn7Ti/vF80XL+YA5H2l7BpCtUr3ya8LWHFzpiO5R+N7dN16ujpIxhekRFuOOF82bXX7K/lg==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -3960,10 +3960,9 @@
 			}
 		},
 		"preact": {
-			"version": "10.18.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.18.1.tgz",
-			"integrity": "sha512-mKUD7RRkQQM6s7Rkmi7IFkoEHjuFqRQUaXamO61E6Nn7vqF/bo7EZCmSyrUnp2UWHw0O7XjZ2eeXis+m7tf4lg==",
-			"peer": true
+			"version": "10.19.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.2.tgz",
+			"integrity": "sha512-UA9DX/OJwv6YwP9Vn7Ti/vF80XL+YA5H2l7BpCtUr3ya8LWHFzpiO5R+N7dN16ujpIxhekRFuOOF82bXX7K/lg=="
 		},
 		"prettier": {
 			"version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"@types/node": "^14.14.33",
 		"@types/resolve": "^1.20.1",
 		"lint-staged": "^10.5.4",
+		"preact": "^10.19.2",
 		"prettier": "^2.2.1",
 		"rimraf": "^3.0.2",
 		"simple-git-hooks": "^2.0.2",
@@ -62,7 +63,7 @@
 		"vite": "^2.6.7"
 	},
 	"lint-staged": {
-		"**/*.{js,jsx,ts,tsx,yml}": [
+		"**/*.{js,jsx,ts,tsx,yml,json}": [
 			"prettier --write"
 		]
 	},


### PR DESCRIPTION
- Adds `tsconfig.json` to `demo/`
  - As we don't set (and can't, due to using `tsc` as the compilation method) the JSX config, TS will (correctly) trip up if you open the demo in an editor.
- Adds `preact` as a devDep
  - Was just testing Vite 5 and had to use `--legacy-peer-deps` as I didn't want to fiddle with versions, but unfortunately Preact was only implicitly included because it's a peer dep. Should probably be a full dev dep.
- Prettifies `.json` on commit else my badly formatted changes to the `package.json` slip through :p