### PR TITLE
refactor: Disable `transform-hook-names` if devtools aren't enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ function preactPlugin({
 							importSource: jsxImportSource ?? "preact",
 						},
 					],
-					...(config.isProduction ? [] : ["babel-plugin-transform-hook-names"]),
+					...(devToolsEnabled && !config.isProduction ? ["babel-plugin-transform-hook-names"] : []),
 				],
 				sourceMaps: true,
 				inputSourceMap: false as any,


### PR DESCRIPTION
Not that this is too heavy, but from my understanding, its only purpose is for the devtools integration and so it should be tied to the `devtoolsEnabled` option.