### PR TITLE
Add config to specify plugin-transform-react-jsx `throwIfNamespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export default defineConfig({
 | `reactAliasesEnabled` | `boolean` | `true` | Aliases `react`, `react-dom` to `preact/compat` |
 | `babel` | `object` | | See [Babel configuration](#babel-configuration) |
 | `prerender` | `object` | | See [Prerendering configuration](#prerendering-configuration) |
+| `jsxOpts` | `object` | | See [Additional JSX configuration](#additional-jsx-configuration) |
 
 #### Babel configuration
 
@@ -112,6 +113,12 @@ export async function prerender(data) {
     };
 }
 ```
+
+#### Additional JSX configuration
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `throwIfNamespace` | `boolean` | `false` | Allows specifying throwIfNamespace for `@babel/plugin-transform-react-jsx` and `@babel/plugin-transform-react-jsx-development` |
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ export type BabelOptions = Omit<
 	| "inputSourceMap"
 >;
 
+export type JsxOptions = {
+	throwIfNamespace?: boolean;
+};
+
 export interface PreactPluginOptions {
 	/**
 	 * Inject devtools bridge in production bundle instead of only in development mode.
@@ -84,6 +88,10 @@ export interface PreactPluginOptions {
 	 * Import Source for jsx. Defaults to "preact".
 	 */
 	jsxImportSource?: string;
+	/**
+	 * Configuration applied to @babel/plugin-transform-react-jsx.
+	 */
+	jsxOpts?: JsxOptions;
 }
 
 export interface PreactBabelOptions extends BabelOptions {
@@ -125,6 +133,7 @@ function preactPlugin({
 	babelOptions.overrides ||= [];
 	babelOptions.parserOpts ||= {} as any;
 	babelOptions.parserOpts.plugins ||= [];
+	babelOptions.jsxOpts ||= {} as any;
 
 	const shouldTransform = createFilter(
 		include || [/\.[tj]sx?$/],
@@ -196,6 +205,7 @@ function preactPlugin({
 							? "@babel/plugin-transform-react-jsx"
 							: "@babel/plugin-transform-react-jsx-development",
 						{
+							...config.jsxOpts,
 							runtime: "automatic",
 							importSource: jsxImportSource ?? "preact",
 						},


### PR DESCRIPTION
It appears that specifying `throwIfNamespace` in a `.babelrc` file no longer causes it to apply to the `@babel/plugin-transform-react-jsx` or `@babel/plugin-transform-react-jsx-development`. Even if specifying `babelrc: true` as a config option.

This is to allow stuff like `unocss` attributify mode which supports attributes like `disabled:bg-grey` on elements.

Currently the only documented use case is `throwIfNamespace`.