### PR TITLE
fix: Normalize URLs w/ trailing slashes

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -291,7 +291,7 @@ export function PrerenderPlugin({
 				if (result.links) {
 					for (let url of result.links) {
 						const parsed = new URL(url, "http://localhost");
-						url = parsed.pathname;
+						url = parsed.pathname.replace(/\/$/, '') || '/';
 						// ignore external links and ones we've already picked up
 						if (seen.has(url) || parsed.origin !== "http://localhost") continue;
 						seen.add(url);


### PR DESCRIPTION
Ensures `/about/we-are-using` and `/about/we-are-using/` match so the latter doesn't create a new output file, overwriting the first (but Rollup does have a helpful warning for when that happens, which is handy).