### PR TITLE
fix: Devtool flag inconsistencies

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -7,12 +7,14 @@ import type { RollupFilter } from "./utils.js";
 import { parseId } from "./utils.js";
 
 export interface PreactDevtoolsPluginOptions {
-	injectInProd?: boolean;
+	devtoolsInProd?: boolean;
+	devToolsEnabled?: boolean;
 	shouldTransform: RollupFilter;
 }
 
 export function preactDevtoolsPlugin({
-	injectInProd = false,
+	devtoolsInProd,
+	devToolsEnabled,
 	shouldTransform,
 }: PreactDevtoolsPluginOptions): Plugin {
 	const log = debug("vite:preact-devtools");
@@ -37,6 +39,8 @@ export function preactDevtoolsPlugin({
 
 		configResolved(resolvedConfig) {
 			config = resolvedConfig;
+			devToolsEnabled =
+				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
 		},
 
 		resolveId(url, importer = "") {
@@ -58,8 +62,8 @@ export function preactDevtoolsPlugin({
 		transform(code, url) {
 			const { id } = parseId(url);
 
-			if (entry === id && (!config.isProduction || injectInProd)) {
-				const source = injectInProd ? "preact/devtools" : "preact/debug";
+			if (entry === id) {
+				const source = devToolsEnabled ? "preact/devtools" : "preact/debug";
 				code = `import "${source}";\n${code}`;
 
 				log(`[inject] ${kl.cyan(source)} -> ${kl.dim(id)}`);

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -62,8 +62,8 @@ export function preactDevtoolsPlugin({
 		transform(code, url) {
 			const { id } = parseId(url);
 
-			if (entry === id) {
-				const source = devToolsEnabled ? "preact/devtools" : "preact/debug";
+			if (entry === id && devToolsEnabled) {
+				const source = devtoolsInProd ? "preact/devtools" : "preact/debug";
 				code = `import "${source}";\n${code}`;
 
 				log(`[inject] ${kl.cyan(source)} -> ${kl.dim(id)}`);

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -62,8 +62,8 @@ export function preactDevtoolsPlugin({
 		transform(code, url) {
 			const { id } = parseId(url);
 
-			if (entry === id && devToolsEnabled) {
-				const source = devtoolsInProd ? "preact/devtools" : "preact/debug";
+			if (entry === id && (!config.isProduction || devToolsEnabled)) {
+				const source = config.isProduction ? "preact/devtools" : "preact/debug";
 				code = `import "${source}";\n${code}`;
 
 				log(`[inject] ${kl.cyan(source)} -> ${kl.dim(id)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ function preactPlugin({
 		exclude || [/node_modules/],
 	);
 
-	devToolsEnabled = devToolsEnabled ?? true;
+	devtoolsInProd = devtoolsInProd ?? false;
 	prefreshEnabled = prefreshEnabled ?? true;
 	reactAliasesEnabled = reactAliasesEnabled ?? true;
 	prerender = prerender ?? { enabled: false };
@@ -158,6 +158,8 @@ function preactPlugin({
 		},
 		configResolved(resolvedConfig) {
 			config = resolvedConfig;
+			devToolsEnabled =
+				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.
@@ -200,7 +202,7 @@ function preactPlugin({
 							importSource: jsxImportSource ?? "preact",
 						},
 					],
-					...(devToolsEnabled && !config.isProduction ? ["babel-plugin-transform-hook-names"] : []),
+					...(devToolsEnabled ? ["babel-plugin-transform-hook-names"] : []),
 				],
 				sourceMaps: true,
 				inputSourceMap: false as any,
@@ -235,14 +237,11 @@ function preactPlugin({
 			  ]
 			: []),
 		jsxPlugin,
-		...(devToolsEnabled
-			? [
-					preactDevtoolsPlugin({
-						injectInProd: devtoolsInProd,
-						shouldTransform,
-					}),
-			  ]
-			: []),
+		preactDevtoolsPlugin({
+			devtoolsInProd,
+			devToolsEnabled,
+			shouldTransform,
+		}),
 		...(prefreshEnabled
 			? [prefresh({ include, exclude, parserPlugins: baseParserOptions })]
 			: []),


### PR DESCRIPTION
Non-breaking form of #112

`devToolsEnabled` becomes a derived value, formed of the user passed option, whether it's a prod build or not, and the user-passed `devtoolsInProd` option.

Still not sure about the devtools source, see below