### PR TITLE
refactor: Use ESBuild in prod if a user does not require Babel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ function preactPlugin({
 						},
 					},
 				},
+				// While this config is unconditional, it'll only be used if Babel is not
 				esbuild: {
 					jsx: "automatic",
 					jsxImportSource: jsxImportSource ?? "preact",

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,12 +167,7 @@ function preactPlugin({
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
 
 			useBabel =
-				!config.isProduction ||
-				devToolsEnabled ||
-				!!babelOptions.plugins.length ||
-				!!babelOptions.presets.length ||
-				!!babelOptions.overrides.length ||
-				!!babelOptions.parserOpts.plugins.length;
+				!config.isProduction || devToolsEnabled || typeof babel !== "undefined";
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,6 @@ function preactPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
-
 			useBabel =
 				!config.isProduction || devToolsEnabled || typeof babel !== "undefined";
 		},


### PR DESCRIPTION
Called out by @ArnaudBarre a few months ago on the Vite Discord (if memory serves), cheers to him for spotting this