### PR TITLE
fix: Sourcemap regex

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -229,7 +229,7 @@ export function PrerenderPlugin({
 					if (output.endsWith(".js") && bundle[output].type == "chunk") {
 						(bundle[output] as OutputChunk).code = (bundle[
 							output
-						] as OutputChunk).code.replace(/^\/\/#\ssourceMappingURL=.*$/, "");
+						] as OutputChunk).code.replace(/\n\/\/#\ssourceMappingURL=.*/, "");
 					}
 				}
 				if (!output.endsWith(".js") || bundle[output].type !== "chunk")


### PR DESCRIPTION
I must've made the (always foolish) decision to make a last-second edit before pushing 🤦

Alternatively could slide a `/m` flag in for the regex, but now that I see this again, I think cleaning up the extraneous newline is preferable?