### PR TITLE
Add @babel/code-frame as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.8.2",
 			"license": "MIT",
 			"dependencies": {
+				"@babel/code-frame": "^7.22.13",
 				"@babel/plugin-transform-react-jsx": "^7.22.15",
 				"@babel/plugin-transform-react-jsx-development": "^7.22.5",
 				"@prefresh/vite": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"dist/"
 	],
 	"dependencies": {
+		"@babel/code-frame": "^7.22.13",
 		"@babel/plugin-transform-react-jsx": "^7.22.15",
 		"@babel/plugin-transform-react-jsx-development": "^7.22.5",
 		"@prefresh/vite": "^2.4.1",


### PR DESCRIPTION
Fixes #121 

- added missing dependency on `@babel/code-frame`, which is used [here](https://github.com/preactjs/preset-vite/blob/main/src/prerender.ts#L7)