### PR TITLE
fix: Support `.cjs` & `.mjs` extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ function preactPlugin({
 
 	let useBabel: boolean;
 	const shouldTransform = createFilter(
-		include || [/\.[tj]sx?$/],
+		include || [/\.[cm]?[tj]sx?$/],
 		exclude || [/node_modules/],
 	);
 


### PR DESCRIPTION
Closes #128

The `.cjs` support is perhaps debatable, not sure if that's really an issue people will run into.