### PR TITLE
feat: Add preview middleware for prerender plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ preact({
 | `renderTarget` | `string` | `"body"` | Query selector for where to insert prerender result in your HTML template |
 | `prerenderScript` | `string` | `undefined` | Absolute path to script containing exported `prerender()` function. If not provided, will try to find the prerender script in the scripts listed in your HTML entrypoint |
 | `additionalPrerenderRoutes` | `string[]` | `undefined` | Prerendering will crawl your site automatically, but you'd like to prerender some pages that may not be found (such as a `/404` page), use this option to specify them |
+| `previewMiddlewareEnabled` | `boolean` | `false` | Vite's preview server as of v5 will not use our prerendered HTML documents automatically. This option enables a middleware that will correct this, allowing you to test the result of prerendering locally |
+| `previewMiddlewareFallback` | `string` | `/index.html` | Fallback path to be used when an HTML document cannot be found via the preview middleware, e.g., `/404` or `/not-found` will be used when the user requests `/some-path-that-does-not-exist` |
 
 To prerender your app, you'll need to do these things:
 1. Enable prerendering in the plugin options

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
 				enabled: true,
 				renderTarget: "#app",
 				additionalPrerenderRoutes: ["/404"],
+				previewMiddlewareEnabled: true,
+				previewMiddlewareFallback: "/404",
 			},
 		}),
 	],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"scripts": {
 		"dev": "vite demo",
 		"dev:build": "vite build demo",
+		"dev:preview": "vite preview demo",
 		"build": "rimraf dist && tsc && tsc -p tsconfig.cjs.json && node tools/postbuild.mjs",
 		"test": "node --test test",
 		"prepublishOnly": "npm run build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { TransformOptions } from "@babel/core";
 import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools.js";
 import { createFilter, parseId } from "./utils.js";
-import { PrerenderPlugin } from "./prerender.js";
+import { PrerenderPlugin, HTMLRoutingMiddlewarePlugin } from "./prerender.js";
 import { transformAsync } from "@babel/core";
 
 export type BabelOptions = Omit<
@@ -64,6 +64,14 @@ export interface PreactPluginOptions {
 		 * Additional routes that should be prerendered
 		 */
 		additionalPrerenderRoutes?: string[];
+		/**
+		 * Vite's preview server won't use our prerendered HTML by default, this middleware correct this
+		 */
+		previewMiddlewareEnabled?: boolean;
+		/**
+		 * Path to use as a fallback/404 route, i.e., `/404` or `/not-found`
+		 */
+		previewMiddlewareFallback?: string;
 	};
 
 	/**
@@ -254,6 +262,13 @@ function preactPlugin({
 			? [prefresh({ include, exclude, parserPlugins: baseParserOptions })]
 			: []),
 		...(prerender.enabled ? [PrerenderPlugin(prerender)] : []),
+		...(prerender.previewMiddlewareEnabled
+			? [
+					HTMLRoutingMiddlewarePlugin({
+						fallback: prerender.previewMiddlewareFallback,
+					}),
+			  ]
+			: []),
 	];
 }
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -469,7 +469,7 @@ export function HTMLRoutingMiddlewarePlugin({
 					await fs.access(file);
 					req.url = url.pathname + "/index.html" + url.search;
 				} catch {
-					req.url = fallback ? fallback + "/index.html" : "/index.html";
+					req.url = (fallback || "") + "/index.html";
 				}
 
 				return next();


### PR DESCRIPTION
As of v5, Vite's preview server will no longer make any attempt to serve anything but `/index.html` for any request missing a file extension -- `/foo` will not result in `/foo/index.html` being returned.

This tends to result in hydration mismatches that users might not expect or recognize; for example, in our demo here (which largely mirrors our template for `create-preact`) we assign an `active` class for items in the header to show which route is active. If the user loads `/404` in their browser, both the "Home" and "404" header items will have the `active` class. It's easy for users to confuse this as a hydration issue with Preact or Preact-ISO when the reality is that the wrong HTML file was returned. 

To fix this, we can add a simple middleware that converts `/foo` into `/foo/index.html` during Vite's preview mode, and if the file isn't found, it falls back to a config option (like `/404`) or to `/index.html`. Naming suggestions certainly welcome & appreciated, not sure if these are as clear as they could be?

Edit: To avoid any potential issues, this is intentionally not enabled by default if the user prerenders their app. Will slip that into the next major though, as I do think it's a better default.

Reference:
 - [Similar plugin in `preact-www`](https://github.com/preactjs/preact-www/blob/master/plugins/html-routing-middleware.js)
- [`preact-iso` issue from this morning](https://github.com/preactjs/preact-iso/issues/33)