### PR TITLE
chore: Fix `"repository"` field in pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
 		"preset"
 	],
 	"author": "The Preact Team (https://preactjs.com)",
-	"repository": "preactjs/preset-vite",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/preactjs/preset-vite.git"
+	},
 	"license": "MIT",
 	"files": [
 		"dist/"


### PR DESCRIPTION
Only saw when I went to publish, seems NPM prefers this form now:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/preactjs/preset-vite.git"
```