### PR TITLE
chore: Remove unused resolve dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"kolorist": "^1.8.0",
 		"magic-string": "0.30.5",
 		"node-html-parser": "^6.1.10",
-		"resolve": "^1.22.8",
 		"source-map": "^0.7.4",
 		"stack-trace": "^1.0.0-pre2"
 	},
@@ -62,7 +61,6 @@
 		"@types/debug": "^4.1.5",
 		"@types/estree": "^0.0.50",
 		"@types/node": "^14.14.33",
-		"@types/resolve": "^1.20.1",
 		"@types/stack-trace": "^0.0.33",
 		"lint-staged": "^10.5.4",
 		"preact": "^10.19.2",


### PR DESCRIPTION
The `resolve` dependency seems to be unused. It's added in https://github.com/preactjs/preset-vite/pull/25 but not needed anymore since https://github.com/preactjs/preset-vite/pull/50