### PR TITLE
fix: Ensure `preact` is optimized by Vite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ function preactPlugin({
 					jsxImportSource: jsxImportSource ?? "preact",
 				},
 				optimizeDeps: {
-					include: ["preact/jsx-runtime", "preact/jsx-dev-runtime"],
+					include: ["preact", "preact/jsx-runtime", "preact/jsx-dev-runtime"],
 				},
 			};
 		},


### PR DESCRIPTION
Closes #76

Corrects a rather bizarre HMR bug.

If the user doesn't directly import anything from `preact` (as our prerender templates do not, instead pulling `hydrate` from `preact-iso`), Vite won't optimize the `preact` dependency (or won't do so in the same way, anyhow) and prefresh will fail to reload any components altered in a module outside of the root (e.g., `/src/components/*`).

Not quite sure why this is yet, but always optimizing preact shouldn't be a problem -- it'll always exist somewhere in the user's app, even if not directly used. Optimizing it won't be a waste.