### PR TITLE
feat: Allow non-text (and non-UTF8) files to be fetched during prerender

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export default defineConfig({
 | `reactAliasesEnabled` | `boolean` | `true` | Aliases `react`, `react-dom` to `preact/compat` |
 | `babel` | `object` | | See [Babel configuration](#babel-configuration) |
 | `prerender` | `object` | | See [Prerendering configuration](#prerendering-configuration) |
+| `fetchEncoding` | `BufferEncoding \| null` | `"utf-8" ` | The encoding used when fetching local files during prerender only. Uses the same rules as [`fs.readFile`](https://nodejs.org/api/fs.html#fsreadfilepath-options-callback)'s `encoding` option. |
 
 #### Babel configuration
 

--- a/demo/public/local-fetch-test.txt
+++ b/demo/public/local-fetch-test.txt
@@ -1,1 +1,1 @@
-Local fetch works
+Local fetch works 🛜

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -190,7 +190,10 @@ export function PrerenderPlugin({
 									viteConfig.root,
 									viteConfig.build.outDir,
 								)}/${url.replace(/^\//, "")}`,
-								fetchEncoding === undefined ? "utf-8" : fetchEncoding,
+								{
+									encoding:
+										fetchEncoding === undefined ? "utf-8" : fetchEncoding,
+								},
 							),
 						);
 					} catch (e: any) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -66,12 +66,14 @@ interface PrerenderPluginOptions {
 	prerenderScript?: string;
 	renderTarget?: string;
 	additionalPrerenderRoutes?: string[];
+	fetchEncoding?: BufferEncoding | null;
 }
 
 export function PrerenderPlugin({
 	prerenderScript,
 	renderTarget,
 	additionalPrerenderRoutes,
+	fetchEncoding,
 }: PrerenderPluginOptions = {}): Plugin {
 	const preloadHelperId = "vite/preload-helper";
 	let viteConfig = {} as ResolvedConfig;
@@ -188,7 +190,7 @@ export function PrerenderPlugin({
 									viteConfig.root,
 									viteConfig.build.outDir,
 								)}/${url.replace(/^\//, "")}`,
-								"utf-8",
+								fetchEncoding === undefined ? "utf-8" : fetchEncoding,
 							),
 						);
 					} catch (e: any) {


### PR DESCRIPTION
I've run into an issue where I need to fetch binary data from a local file, and while this is fine at runtime, the patched version of `fetch` that prerendering uses always decodes all local files as text via UTF-8.

All this change includes is a `fetchEncoding` option for the `PrerenderPlugin` that, when not `undefined`, specifies the encoding passed to `fs.readFile`. I'm not sure this is the ideal solution to the problem (e.g. it's unfortunate that `null` and `undefined` end up being treated differently, and I don't know about `fetchEncoding` as a name), so I'm more than okay with any alternative method—I can open an issue instead if that's the better route for this.