### PR TITLE
refactor: Provide original, unpatched fetch impl on globalThis

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -177,7 +177,8 @@ export function PrerenderPlugin({
 			globalThis.__VITE_PRELOAD__ = [];
 
 			// Local, fs-based fetch implementation for prerendering
-			const nodeFetch = globalThis.fetch;
+			// @ts-ignore
+			globalThis.unpatchedFetch = globalThis.fetch;
 			// @ts-ignore
 			globalThis.fetch = async (url: string, opts: RequestInit | undefined) => {
 				if (/^\//.test(url)) {
@@ -197,7 +198,8 @@ export function PrerenderPlugin({
 					}
 				}
 
-				return nodeFetch(url, opts);
+				// @ts-ignore
+				return globalThis.unpatchedFetch(url, opts);
 			};
 
 			// Grab the generated HTML file, which we'll use as a template:


### PR DESCRIPTION
`originalFetch`? `vanillaFetch`? `Fetch`? Naming is hard, certainly looking for better names if ya got 'em.

---

Current setup makes it a bit more verbose to provide your own fetch impl, as we override without providing any way for consumers to get the original. You'd have to add `globalThis.unpatchedFetch = globalThis.fetch;` into your Vite config file for later retrieval in your app, which isn't ideal.