### PR TITLE
feat: Prerender data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ export async function prerender(data) {
         // Optionally add additional links that should be
         // prerendered (if they haven't already been)
         links: new Set([...discoveredLinks, '/foo', '/bar']),
+        // Optional data to serialize into a script tag for use on the client:
+        //   <script type="application/json" id="preact-prerender-data">{"url":"/"}</script>
+        data: { url: data.url },
         // Optionally configure and add elements to the `<head>` of
         // the prerendered HTML document
         head: {

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -29,11 +29,12 @@ if (typeof window !== "undefined") {
 	hydrate(<App />, document.getElementById("app"));
 }
 
-export async function prerender() {
+export async function prerender(data) {
 	const { html, links } = await ssr(<App />);
 	return {
 		html,
 		links,
+		data: { url: data.url },
 		head: {
 			lang: "en",
 			title: "Prerendered Preact App",

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -378,6 +378,11 @@ export function PrerenderPlugin({
 					if (result.head) {
 						head = result.head;
 					}
+					if (result.data) {
+						body += `<script type="application/json" id="preact-prerender-data">${JSON.stringify(
+							result.data,
+						)}</script>`;
+					}
 				} else {
 					body = result;
 				}

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -23,6 +23,12 @@ test("builds demo successfully", async () => {
 	assert.match(outputHtml, /<title>Prerendered Preact App<\/title>/);
 	assert.match(outputHtml, /<meta name="description" content="This is a prerendered Preact app">/);
 
+	// Prerender Data
+	assert.match(
+		outputHtml,
+		/<script type="application\/json" id="preact-prerender-data">{"url":"\/"}<\/script>/
+	);
+
 	// Local Fetch
 	assert.match(outputHtml, /Local fetch works/);
 


### PR DESCRIPTION
Same API we used for WMR.

I believe I skipped adding this originally as `preact-iso` was injecting its own script tag as a marker for hydration and I wasn't quite sure whether this should fall on the prerender plugin side of things or iso. I'm leaning towards the prerender plugin now (as shown by this PR), but can go either way.