### PR TITLE
fix: unable to find TS types under ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
 	"module": "./dist/esm/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/types/index.d.ts",
 			"import": "./dist/esm/index.mjs",
 			"require": "./dist/cjs/index.js"
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "dist/types/index.d.ts",
+	"types": "dist/cjs/index.d.ts",
 	"scripts": {
 		"dev": "vite demo",
 		"dev:build": "vite build demo",

--- a/tools/postbuild.mjs
+++ b/tools/postbuild.mjs
@@ -8,10 +8,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dir = path.join(__dirname, "..", "dist", "esm");
 
 for (const file of fs.readdirSync(dir)) {
-	const target = path.join(
-		dir,
-		path.basename(file, path.extname(file)) + ".mjs",
-	);
+	const ext = file.endsWith(".d.ts") ? ".mts" : ".mjs";
+	const target = path.join(dir, path.basename(file, path.extname(file)) + ext);
 
 	fs.renameSync(path.join(dir, file), target);
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,8 +2,6 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"outDir": "dist/cjs/",
-		"module": "CommonJS",
-		"declaration": true,
-		"declarationDir": "dist/types/"
+		"module": "CommonJS"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"esModuleInterop": true,
 		"module": "ESNext",
 		"moduleResolution": "Node",
+		"declaration": true,
 		"outDir": "dist/esm/"
 	},
 	"files": ["./src/index.ts"]


### PR DESCRIPTION
Noticed that the types weren't found under ESM. TypeScript these days needs separate declaration files for ESM and CJS. With the help of https://arethetypeswrong.github.io/ the changes in this PR ensure that types can be found in all scenarios.

Fixes https://github.com/denoland/deno/issues/25529