### PR TITLE
feat: bump vite peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "7.x",
-				"vite": "2.x || 3.x || 4.x || 5.x"
+				"vite": "2.x || 3.x || 4.x || 5.x || 6.x"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",
-		"vite": "2.x || 3.x || 4.x || 5.x"
+		"vite": "2.x || 3.x || 4.x || 5.x || 6.x"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.15.8",


### PR DESCRIPTION
Bumps range for vite peer dependency to include new v6 version, no breaking changes required.

[Vite 5 to 6 migration/breaking changes](https://main.vitejs.dev/guide/migration)