### PR TITLE
2.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.1",
+	"version": "2.9.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@preact/preset-vite",
-			"version": "2.9.1",
+			"version": "2.9.2",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.1",
+	"version": "2.9.2",
 	"description": "Preact preset for the vite bundler",
 	"main": "./dist/cjs/index.js",
 	"module": "./dist/esm/index.mjs",


### PR DESCRIPTION
## Maintenance

- Bump allowed PeerDependency of vite to include 6.x