### PR TITLE
refactor: Ensure module preload polyfill is inlined into main bundle

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -140,11 +140,11 @@ export function PrerenderPlugin({
 			// We're only going to alter the chunking behavior in the default cases, where the user and/or
 			// other plugins haven't already configured this. It'd be impossible to avoid breakages otherwise.
 			if (
-				(Array.isArray(config.build.rollupOptions.output) &&
-					(config.build.rollupOptions as OutputOptions[])?.length > 1) ||
+				Array.isArray(config.build.rollupOptions.output) ||
 				(config.build.rollupOptions.output as OutputOptions)?.manualChunks
-			)
+			) {
 				return;
+			}
 
 			config.build.rollupOptions.output ??= {};
 			(config.build.rollupOptions.output as OutputOptions).manualChunks = (

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -173,15 +173,15 @@ export function PrerenderPlugin({
 						: { ...opts.input, prerenderEntry: prerenderScript };
 			opts.preserveEntrySignatures = "allow-extension";
 		},
-		// Injects a window check into Vite's preload helper, instantly resolving
-		// the module rather than attempting to add a <link> to the document.
+		// Injects window checks into Vite's preload helper & modulepreload polyfill
 		transform(code, id) {
-			// Vite keeps changing up the ID, best we can do for cross-version
-			// compat is an `includes`
 			if (id.includes(preloadHelperId)) {
+				// Injects a window check into Vite's preload helper, instantly resolving
+				// the module rather than attempting to add a <link> to the document.
+				const s = new MagicString(code);
+
 				// Through v5.0.4
 				// https://github.com/vitejs/vite/blob/b93dfe3e08f56cafe2e549efd80285a12a3dc2f0/packages/vite/src/node/plugins/importAnalysisBuild.ts#L95-L98
-				const s = new MagicString(code);
 				s.replace(
 					`if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {`,
 					`if (!__VITE_IS_MODERN__ || !deps || deps.length === 0 || typeof window === 'undefined') {`,
@@ -200,6 +200,7 @@ export function PrerenderPlugin({
 				const s = new MagicString(code);
 				// Replacement for `'link'` && `"link"` as the output from their tooling has
 				// differed over the years. Should be better than switching to regex.
+				// https://github.com/vitejs/vite/blob/20fdf210ee0ac0824b2db74876527cb7f378a9e8/packages/vite/src/node/plugins/modulePreloadPolyfill.ts#L62
 				s.replace(
 					`const relList = document.createElement('link').relList;`,
 					`if (typeof window === "undefined") return;\n  const relList = document.createElement('link').relList;`,

--- a/test/build.test.mjs
+++ b/test/build.test.mjs
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { test } from "node:test";
 import { promisify } from "node:util";
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import assert from "node:assert";
 import { dir } from "./util.mjs";
 
@@ -34,4 +35,8 @@ test("builds demo successfully", async () => {
 
 	// `additionalPrerenderRoutes` config option
 	assert.doesNotThrow(async () => await fs.access(dir("demo/dist/404/index.html")));
+
+	const outputFiles = await fs.readdir(path.join(dir("demo/dist"), 'assets'));
+	const outputIndexJS = outputFiles.filter(f => /^index\..+\.js$/.test(f));
+	assert.strictEqual(outputIndexJS.length, 1);
 });


### PR DESCRIPTION
This has been a fairly long-standing issue in the prerenderer that I've unfortunately just not had the time to track down.

The issue is that Rollup/Vite notices both the web entry chunk & the prerender chunk (containing, at a realistic minimum, rts) both depend on a number of shared modules (`preact`, amongst others) and so it will extract out those shared modules to a separate chunk. This gives us an app entry module like the following:

```js
import '/index.hash123.js';
function modulePreloadPolyfill() { ... }
```

You can see this if you load up the Preact docs site, the first JS file that's downloaded is just a static import of our actual app & Vite's modulepreload polyfill -- not ideal.

Vite has always added a modulepreload link with the real bundle path, and with this entry being so tiny I wasn't too concerned with the delay it'd cause, but it probably is a wasted ~20+ms on average which is far from optimal.

---

This PR corrects the behavior, ensuring our bundle & the preload polyfill are merged. This means we have to patch the preload polyfill with a window check too, as the polyfill is an IIFE and the prerender chunk now relies on it, but that should be fine.