### PR TITLE
refactor: Silence Rollup warnings regarding source maps & use directives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,9 +153,23 @@ function preactPlugin({
 				build: {
 					rollupOptions: {
 						onwarn(warning, warn) {
-							// Silence Rollup's module-level directive warnings -- they're likely
-							// to all come from `node_modules` (RSCs) and won't be actionable.
-							if (warning.code === "MODULE_LEVEL_DIRECTIVE") return;
+							// Silence Rollup's module-level directive warnings re:"use client".
+							// They're likely to come from `node_modules` and won't be actionable.
+							if (
+								warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+								warning.message.includes("use client")
+							)
+								return;
+							// ESBuild seemingly doesn't include mappings for directives, causing
+							// Rollup to emit warnings about missing source locations. This too is
+							// likely to come from `node_modules` and won't be actionable.
+							// evanw/esbuild#3548
+							if (
+								warning.code === "SOURCEMAP_ERROR" &&
+								warning.message.includes("resolve original location") &&
+								warning.pos === 0
+							)
+								return;
 							warn(warning);
 						},
 					},


### PR DESCRIPTION
Someone [mentioned this in Slack](https://preact.slack.com/archives/C3NMBSJKH/p1735560924649199) the other day. It appears as though any use of the `'use client'` directive w/ sourcemaps enabled will trigger this warning, and do so per file -- react query & MUI (apparently) result in a lot of terminal spam as such.

Reference:
 - https://github.com/vitejs/vite-plugin-react/pull/369
 - https://github.com/evanw/esbuild/issues/3548