### PR TITLE
2.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.3",
+	"version": "2.9.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@preact/preset-vite",
-			"version": "2.9.3",
+			"version": "2.9.4",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.3",
+	"version": "2.9.4",
 	"description": "Preact preset for the vite bundler",
 	"main": "./dist/cjs/index.js",
 	"module": "./dist/esm/index.mjs",


### PR DESCRIPTION
## Fixes

- Silence Rollup warnings for `node_modules` with `'use client'`
- Ensure prerenderer is using source maps to provide better error locations