### PR TITLE
fix: Support Deno

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ import { preactDevtoolsPlugin } from "./devtools.js";
 import { createFilter, parseId } from "./utils.js";
 import { vitePrerenderPlugin } from "vite-prerender-plugin";
 import { transformAsync } from "@babel/core";
+// @ts-ignore package doesn't ship with declaration files
+import babelReactJsx from "@babel/plugin-transform-react-jsx";
+// @ts-ignore package doesn't ship with declaration files
+import babelReactJsxDev from "@babel/plugin-transform-react-jsx-development";
+// @ts-ignore package doesn't ship with declaration files
+import babelHookNames from "babel-plugin-transform-hook-names";
 
 export type BabelOptions = Omit<
 	TransformOptions,
@@ -234,15 +240,13 @@ function preactPlugin({
 				plugins: [
 					...babelOptions.plugins,
 					[
-						config.isProduction
-							? "@babel/plugin-transform-react-jsx"
-							: "@babel/plugin-transform-react-jsx-development",
+						config.isProduction ? babelReactJsx : babelReactJsxDev,
 						{
 							runtime: "automatic",
 							importSource: jsxImportSource ?? "preact",
 						},
 					],
-					...(devToolsEnabled ? ["babel-plugin-transform-hook-names"] : []),
+					...(devToolsEnabled ? [babelHookNames] : []),
 				],
 				sourceMaps: true,
 				inputSourceMap: false as any,


### PR DESCRIPTION
The way dependencies work in Deno is that they must be reachable through the module graph. But because the way we loaded the babel plugins is not analysable, the dependencies weren't found.

This PR switches the old school dynamic string-based loading to standard ESM imports.

Fixes https://github.com/denoland/deno/issues/27432