### PR TITLE
2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.4",
+	"version": "2.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@preact/preset-vite",
-			"version": "2.9.4",
+			"version": "2.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/plugin-transform-react-jsx": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@preact/preset-vite",
-	"version": "2.9.4",
+	"version": "2.10.0",
 	"description": "Preact preset for the vite bundler",
 	"main": "./dist/cjs/index.js",
 	"module": "./dist/esm/index.mjs",


### PR DESCRIPTION
## Minor

- Switch to `vite-prerender-plugin` (#153)

## Fixes

- fix: missing dependency in Deno (#154)