### PR TITLE
fix: do not set jsxImportSource when using babel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ function preactPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
-			useBabel ||= !config.isProduction || devToolsEnabled;
+			useBabel ||= !config.isProduction || !!devToolsEnabled;
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ function preactPlugin({
 	babelOptions.parserOpts ||= {} as any;
 	babelOptions.parserOpts.plugins ||= [];
 
-	let useBabel: boolean;
+	let useBabel = typeof babel !== "undefined";
 	const shouldTransform = createFilter(
 		include || [/\.[cm]?[tj]sx?$/],
 		exclude || [/node_modules/],
@@ -191,10 +191,12 @@ function preactPlugin({
 					},
 				},
 				// While this config is unconditional, it'll only be used if Babel is not
-				esbuild: {
-					jsx: "automatic",
-					jsxImportSource: jsxImportSource ?? "preact",
-				},
+				esbuild: useBabel
+					? undefined
+					: {
+							jsx: "automatic",
+							jsxImportSource: jsxImportSource ?? "preact",
+					  },
 				optimizeDeps: {
 					include: ["preact", "preact/jsx-runtime", "preact/jsx-dev-runtime"],
 				},
@@ -204,8 +206,7 @@ function preactPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
-			useBabel =
-				!config.isProduction || devToolsEnabled || typeof babel !== "undefined";
+			useBabel ||= !config.isProduction || !!devToolsEnabled;
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,6 @@ function preactPlugin({
 						},
 					},
 				},
-				// While this config is unconditional, it'll only be used if Babel is not
 				esbuild: useBabel
 					? undefined
 					: {
@@ -206,7 +205,7 @@ function preactPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
-			useBabel ||= !config.isProduction || !!devToolsEnabled;
+			useBabel ||= !config.isProduction || devToolsEnabled;
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.


### PR DESCRIPTION
In Astro if you use react and preact in the same project, setting `jsxImportSource` to preact causes things to fail. This PR makes it so that using babel will not set esbuild options