### PR TITLE
fix: force non-legacy import attributes babel output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ function preactPlugin({
 				},
 				generatorOpts: {
 					...babelOptions.generatorOpts,
+					importAttributesKeyword: 'with',
 					decoratorsBeforeExport: true,
 				},
 				plugins: [


### PR DESCRIPTION
Same issues as is in react version 
https://github.com/vitejs/vite-plugin-react/pull/386/files