### PR TITLE
fix: Add jsx-runtime to aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ function preactPlugin({
 									alias: {
 										"react-dom/test-utils": "preact/test-utils",
 										"react-dom": "preact/compat",
+                                        "react/jsx-runtime": "preact/jsx-runtime",
 										react: "preact/compat",
 									},
 								},


### PR DESCRIPTION
Seeing this at work, Vite won't chase open-ended aliases (like `react` -> `preact/compat`, which can become `preact/compat/client`, `preact/compat/server`, `preact/compat/jsx-runtime`, etc) when optimizing ahead of time, choosing to instead defer that to detected usage during runtime (which is completely reasonable, IMO). Cacheless starts therefore see Vite refresh the page upon first load when it discovers & optimizes "react/jsx-runtime" which is a bit slower.

Can make the argument that all `/compat/*` entries should be listed here accordingly, though I'm not sure any of the other entries are likely to be used.

cc @maybebot, in a few weeks we'll get to delete a single line of config