### PR TITLE
chore: Bump Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
 		"trailingComma": "all"
 	},
 	"volta": {
-		"node": "18.12.1"
+		"node": "20.x"
 	}
 }


### PR DESCRIPTION
18 is EOL as of March earlier this year