### PR TITLE
Upgrade @rollup/pluginutils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@babel/plugin-transform-react-jsx": "^7.27.1",
 				"@babel/plugin-transform-react-jsx-development": "^7.27.1",
 				"@prefresh/vite": "^2.4.11",
-				"@rollup/pluginutils": "^4.1.1",
+				"@rollup/pluginutils": "^5.0.0",
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.4.3",
 				"picocolors": "^1.1.1",
@@ -432,10 +432,11 @@
 				"vite": ">=2.0.0"
 			}
 		},
-		"node_modules/@rollup/pluginutils": {
+		"node_modules/@prefresh/vite/node_modules/@rollup/pluginutils": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
 			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"license": "MIT",
 			"dependencies": {
 				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
@@ -443,6 +444,46 @@
 			"engines": {
 				"node": ">= 8.0.0"
 			}
+		},
+		"node_modules/@prefresh/vite/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+			"integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -1188,15 +1229,16 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -1241,11 +1283,12 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -1355,6 +1398,7 @@
 			"version": "2.77.3",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
 			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+			"peer": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -1474,9 +1518,10 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "2.9.16",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-			"integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+			"version": "2.9.18",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
+			"integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.14.27",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@babel/plugin-transform-react-jsx": "^7.27.1",
 		"@babel/plugin-transform-react-jsx-development": "^7.27.1",
 		"@prefresh/vite": "^2.4.11",
-		"@rollup/pluginutils": "^4.1.1",
+		"@rollup/pluginutils": "^5.0.0",
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.4.3",
 		"picocolors": "^1.1.1",
@@ -81,6 +81,6 @@
 		"trailingComma": "all"
 	},
 	"volta": {
-		"node": "20.x"
+		"node": "20.19.6"
 	}
 }


### PR DESCRIPTION
This upgrade fixes a typescript issue when installing our preset and using a TypeScript vite config without "checkJS" and "strict" true (a not uncommon setup).

In version 4, @rollup/pluginutils doesn't provides a "types" field in the "exports" of their package.json. v5 fixes that so the types resolve correctly.

See this gist for the minimal setup I was using to repro: https://gist.github.com/andrewiggins/9295086feadac9e3d978d5bafd8ea8cc

I believe the only breaking change is requiring Node 14:
- https://github.com/rollup/plugins/blob/master/packages/pluginutils/CHANGELOG.md#v500
- https://github.com/rollup/plugins/pull/1287