### PR TITLE
perf: avoid babel in dev by using magic string for hook names injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
 				"@rollup/pluginutils": "^5.0.0",
 				"babel-plugin-transform-hook-names": "^1.0.2",
 				"debug": "^4.4.3",
+				"magic-string": "^0.30.21",
 				"picocolors": "^1.1.1",
-				"vite-prerender-plugin": "^0.5.8"
+				"vite-prerender-plugin": "^0.5.8",
+				"zimmerframe": "^1.1.4"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.28.5",
@@ -381,9 +383,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
@@ -1207,6 +1209,15 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1569,20 +1580,17 @@
 				"stack-trace": "^1.0.0-pre2"
 			}
 		},
-		"node_modules/vite-prerender-plugin/node_modules/magic-string": {
-			"version": "0.30.17",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"license": "ISC"
+		},
+		"node_modules/zimmerframe": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+			"license": "MIT"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
 		"@rollup/pluginutils": "^5.0.0",
 		"babel-plugin-transform-hook-names": "^1.0.2",
 		"debug": "^4.4.3",
+		"magic-string": "^0.30.21",
 		"picocolors": "^1.1.1",
-		"vite-prerender-plugin": "^0.5.8"
+		"vite-prerender-plugin": "^0.5.8",
+		"zimmerframe": "^1.1.4"
 	},
 	"peerDependencies": {
 		"@babel/core": "7.x",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { TransformOptions } from "@babel/core";
 
 import prefresh from "@prefresh/vite";
 import { preactDevtoolsPlugin } from "./devtools.js";
+import { transformHookNamesPlugin } from "./transform-hook-names.js";
 import { createFilter, parseId } from "./utils.js";
 import { vitePrerenderPlugin } from "vite-prerender-plugin";
 import { transformAsync } from "@babel/core";
@@ -140,7 +141,7 @@ function preactPlugin({
 	babelOptions.parserOpts ||= {} as any;
 	babelOptions.parserOpts.plugins ||= [];
 
-	let useBabel = typeof babel !== "undefined";
+	const useBabel = typeof babel !== "undefined";
 	const shouldTransform = createFilter(
 		include || [/\.[cm]?[tj]sx?$/],
 		exclude || [/node_modules/],
@@ -205,7 +206,6 @@ function preactPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
-			useBabel ||= !config.isProduction || !!devToolsEnabled;
 		},
 		async transform(code, url) {
 			// Ignore query parameters, as in Vue SFC virtual modules.
@@ -272,7 +272,7 @@ function preactPlugin({
 									alias: {
 										"react-dom/test-utils": "preact/test-utils",
 										"react-dom": "preact/compat",
-                                        "react/jsx-runtime": "preact/jsx-runtime",
+										"react/jsx-runtime": "preact/jsx-runtime",
 										react: "preact/compat",
 									},
 								},
@@ -282,6 +282,15 @@ function preactPlugin({
 			  ]
 			: []),
 		jsxPlugin,
+		...(!useBabel
+			? [
+					transformHookNamesPlugin({
+						devtoolsInProd,
+						devToolsEnabled,
+						shouldTransform,
+					}),
+			  ]
+			: []),
 		preactDevtoolsPlugin({
 			devtoolsInProd,
 			devToolsEnabled,

--- a/src/transform-hook-names.ts
+++ b/src/transform-hook-names.ts
@@ -1,0 +1,144 @@
+import { extractAssignedNames } from "@rollup/pluginutils";
+import type { Node, Program } from "estree";
+import MagicString from "magic-string";
+import type { Plugin } from "vite";
+import { walk } from "zimmerframe";
+
+import type { RollupFilter } from "./utils.js";
+import { parseId } from "./utils.js";
+
+const HOOK_IMPORTS = new Set(["preact/hooks", "preact/compat", "react"]);
+const HOOK_NAME_RE = /^(useState|useReducer|useRef|useMemo)$/;
+const FILTER_CODE_RE = /\buse(?:State|Reducer|Ref|Memo)\b/;
+
+type NodeWithRange<N extends Node = Node> = N & {
+	start: number;
+	end: number;
+};
+
+export interface TransformHookNamesPluginOptions {
+	devtoolsInProd?: boolean;
+	devToolsEnabled?: boolean;
+	shouldTransform: RollupFilter;
+}
+
+export function transformHookNamesPlugin({
+	devtoolsInProd,
+	devToolsEnabled,
+	shouldTransform,
+}: TransformHookNamesPluginOptions): Plugin {
+	return {
+		name: "preact:transform-hook-names",
+		configResolved(config) {
+			devToolsEnabled =
+				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
+		},
+		transform(code, url) {
+			if (!devToolsEnabled) return;
+
+			const { id } = parseId(url);
+			if (!shouldTransform(id)) return;
+			if (!FILTER_CODE_RE.test(code)) return;
+
+			let ast: NodeWithRange<Program>;
+			try {
+				ast = this.parse(code) as NodeWithRange<Program>;
+			} catch {
+				return;
+			}
+
+			const importedHooks = getImportedHooks(ast);
+			if (importedHooks.size === 0) return;
+
+			const s = new MagicString(code);
+			let hasHelper = false;
+			walk<NodeWithRange, null>(ast, null, {
+				CallExpression(node, { path, next }) {
+					const callee = node.callee;
+					if (callee.type !== "Identifier") {
+						next();
+						return;
+					}
+
+					const hookName = callee.name;
+					// the hook name might be shadowed by a local variable,
+					// but that false-positive is fine
+					// since `addHookName` is transparent
+					if (!HOOK_NAME_RE.test(hookName) || !importedHooks.has(hookName)) {
+						next();
+						return;
+					}
+
+					const parent = path[path.length - 1];
+					const bindingNames = getOuterBindingNames(parent);
+					if (bindingNames.length === 0) {
+						next();
+						return;
+					}
+
+					let name = bindingNames[0];
+					hasHelper = true;
+					s.prependLeft(node.start, "addHookName(");
+					s.appendRight(node.end, `, ${JSON.stringify(name)})`);
+					next();
+				},
+			});
+			if (!hasHelper) return;
+
+			const firstNode = ast.body[0] as NodeWithRange;
+			s.prependLeft(
+				firstNode.start,
+				'import { addHookName } from "preact/devtools";\n',
+			);
+
+			return {
+				code: s.toString(),
+				map: s.generateMap({ hires: "boundary" }),
+			};
+		},
+	};
+}
+
+function getImportedHooks(ast: NodeWithRange<Program>): Set<string> {
+	const hooks = new Set<string>();
+	for (const node of ast.body) {
+		if (node.type !== "ImportDeclaration") continue;
+
+		const source =
+			typeof node.source.value === "string" ? node.source.value : null;
+		if (!source || !HOOK_IMPORTS.has(source)) continue;
+
+		for (const specifier of node.specifiers) {
+			if (specifier.type !== "ImportSpecifier") continue;
+
+			const importedName = specifier.imported.name;
+			if (
+				!HOOK_NAME_RE.test(importedName) ||
+				specifier.local.name !== importedName
+			)
+				continue;
+
+			hooks.add(importedName);
+		}
+	}
+	return hooks;
+}
+
+function getOuterBindingNames(node: Node | undefined): string[] {
+	if (!node) return [];
+
+	switch (node.type) {
+		case "VariableDeclarator":
+			return extractAssignedNames(node.id);
+		case "AssignmentExpression":
+			return extractAssignedNames(node.left);
+		case "Identifier":
+		case "ArrayPattern":
+		case "ObjectPattern":
+		case "RestElement":
+		case "AssignmentPattern":
+			return extractAssignedNames(node);
+		default:
+			return [];
+	}
+}


### PR DESCRIPTION
This PR adds transformHookNamesPlugin which is a port of babel-plugin-transform-hook-names and uses magic-string to update the code instead of babel. With this change, babel no longer has to be run unless it's specified by the option. This improves performance by up to 31%.

### Benchmark
I tested this change with a benchmark script at https://github.com/sapphi-red/preset-vite/commit/2ff89c2664305e57c8bb4af1ebc16668e667ed48.

#### 2000 Components without any hook calls
` npm run benchmark:load -- --files 2000 --children 5 --runs 5 --warmups 1`

- Without this PR: 3071.20ms
- With this PR: 2110.64ms (-960.56ms, -31.28%)

#### 2000 Components with `useState` calls
`npm run benchmark:load -- --files 2000 --children 5 --runs 5 --warmups 1 --use-state`

- Without this PR: 3515.42ms
- With this PR: 2641.48ms (-873.94ms, -24.87%)

