### PR TITLE
add vite-plugin keyword for registry discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"keywords": [
 		"preact",
 		"vite",
+		"vite-plugin",
 		"vite-preset",
 		"preset"
 	],


### PR DESCRIPTION
## Summary
- add the `vite-plugin` npm keyword to `@preact/preset-vite`
- make the package discoverable by `https://registry.vite.dev/`, which indexes plugins from npm keywords

This comes from https://registry.vite.dev/guide/discovery