### PR TITLE
refactor: Skip resolveId & transform hooks for devtools plugin if not enabled

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -44,6 +44,7 @@ export function preactDevtoolsPlugin({
 		},
 
 		resolveId(url, importer = "") {
+			if (!devToolsEnabled) return;
 			const { id } = parseId(url);
 
 			// Get the main entry file to inject into
@@ -60,9 +61,10 @@ export function preactDevtoolsPlugin({
 		},
 
 		transform(code, url) {
+			if (!devToolsEnabled) return;
 			const { id } = parseId(url);
 
-			if (entry === id && (!config.isProduction || devToolsEnabled)) {
+			if (entry === id) {
 				const source = config.isProduction ? "preact/devtools" : "preact/debug";
 				code = `import "${source}";\n${code}`;
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -17,6 +17,7 @@ export function preactDevtoolsPlugin({
 	devToolsEnabled,
 	shouldTransform,
 }: PreactDevtoolsPluginOptions): Plugin {
+	const name = "preact:devtools";
 	const log = debug("vite:preact-devtools");
 
 	let entry = "";
@@ -24,7 +25,7 @@ export function preactDevtoolsPlugin({
 	let found = false;
 
 	const plugin: Plugin = {
-		name: "preact:devtools",
+		name,
 
 		// Ensure that we resolve before everything else
 		enforce: "pre",
@@ -41,10 +42,23 @@ export function preactDevtoolsPlugin({
 			config = resolvedConfig;
 			devToolsEnabled =
 				devToolsEnabled ?? (!config.isProduction || devtoolsInProd);
+
+			// Whilst newer versions of Vite allow for hook filtering, we'd need to set the filter
+			// after the fact as we can only read `config.isProduction` here. And if we're setting
+			// the filter after the fact, well, we can just remove the plugin hooks entirely. Skips
+			// filtering altogether.
+			if (!devToolsEnabled) {
+				const devToolsPlugin = config.plugins.find(
+					(p: Plugin) => p.name === name,
+				);
+				if (devToolsPlugin) {
+					delete devToolsPlugin.resolveId;
+					delete devToolsPlugin.transform;
+				}
+			}
 		},
 
 		resolveId(url, importer = "") {
-			if (!devToolsEnabled) return;
 			const { id } = parseId(url);
 
 			// Get the main entry file to inject into
@@ -61,7 +75,6 @@ export function preactDevtoolsPlugin({
 		},
 
 		transform(code, url) {
-			if (!devToolsEnabled) return;
 			const { id } = parseId(url);
 
 			if (entry === id) {


### PR DESCRIPTION
Switching to Vite 8 / Rolldown at work and found the devtools plugin was taking a silly amount of time (10% of our build) despite not actually being enabled in our production builds. ~~This is a common-sense first step that'll help all users, though to a relatively minor degree in Rolldown. Real fix there is hook filters which I'll land in a follow-up PR~~

Edit: So I spent ~40 minutes trying different filtering setups to ensure it'd work with older Vite versions and just settled on this rather than making a follow-up. When the plugin is initialized, we'd never know whether `devToolsEnabled` is going to be set or not as we'd only discover that as part of `configResolved()`. As such, we'd have to set/update the filters for `resolveId()` and `transform()` from within `configResolved()`, and if we were already doing that, why not just delete the unneeded plugin hooks altogether? A lot simpler and we don't have to worry at all about version compatibility? Not needing to filter should also make this faster.

CC @maybebot 