### PR TITLE
Add changesets based publishing

### DIFF
--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,0 +1,88 @@
+import { appendFileSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const ignoredDirectories = new Set([
+  ".git",
+  "dist",
+  "node_modules",
+]);
+
+async function findPackageManifests(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const manifests = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        manifests.push(...await findPackageManifests(fullPath));
+      }
+    } else if (entry.isFile() && entry.name === "package.json") {
+      const pkg = JSON.parse(await readFile(fullPath, "utf8"));
+
+      if (!pkg.private && pkg.name && pkg.version) {
+        manifests.push({ name: pkg.name, version: pkg.version });
+      }
+    }
+  }
+
+  return manifests;
+}
+
+async function hasPublishedVersion(pkg) {
+  const response = await fetch(
+    `https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`,
+    { headers: { accept: "application/vnd.npm.install-v1+json" } },
+  );
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to query ${pkg.name}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const metadata = await response.json();
+  return Object.prototype.hasOwnProperty.call(
+    metadata.versions ?? {},
+    pkg.version,
+  );
+}
+
+async function main() {
+  const packages = (await findPackageManifests(process.cwd()))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  let hasUnpublished = false;
+
+  for (const pkg of packages) {
+    const isPublished = await hasPublishedVersion(pkg);
+
+    if (isPublished) {
+      console.log(`${pkg.name}@${pkg.version} is already published`);
+    } else {
+      console.log(`${pkg.name}@${pkg.version} is not published yet`);
+      hasUnpublished = true;
+    }
+  }
+
+  const output = [
+    `has_unpublished=${String(hasUnpublished)}`,
+    `should_publish=${String(hasUnpublished)}`,
+  ].join("\n") + "\n";
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/has-unpublished-packages.mjs
+++ b/.github/scripts/has-unpublished-packages.mjs
@@ -1,35 +1,5 @@
 import { appendFileSync } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
-import path from "node:path";
-
-const ignoredDirectories = new Set([
-  ".git",
-  "dist",
-  "node_modules",
-]);
-
-async function findPackageManifests(directory) {
-  const entries = await readdir(directory, { withFileTypes: true });
-  const manifests = [];
-
-  for (const entry of entries) {
-    const fullPath = path.join(directory, entry.name);
-
-    if (entry.isDirectory()) {
-      if (!ignoredDirectories.has(entry.name)) {
-        manifests.push(...await findPackageManifests(fullPath));
-      }
-    } else if (entry.isFile() && entry.name === "package.json") {
-      const pkg = JSON.parse(await readFile(fullPath, "utf8"));
-
-      if (!pkg.private && pkg.name && pkg.version) {
-        manifests.push({ name: pkg.name, version: pkg.version });
-      }
-    }
-  }
-
-  return manifests;
-}
+import { readFile } from "node:fs/promises";
 
 async function hasPublishedVersion(pkg) {
   const response = await fetch(
@@ -55,24 +25,19 @@ async function hasPublishedVersion(pkg) {
 }
 
 async function main() {
-  const packages = (await findPackageManifests(process.cwd()))
-    .sort((a, b) => a.name.localeCompare(b.name));
-  let hasUnpublished = false;
+  const pkg = JSON.parse(await readFile("package.json", "utf8"));
+  const isPublished = await hasPublishedVersion(pkg);
 
-  for (const pkg of packages) {
-    const isPublished = await hasPublishedVersion(pkg);
-
-    if (isPublished) {
-      console.log(`${pkg.name}@${pkg.version} is already published`);
-    } else {
-      console.log(`${pkg.name}@${pkg.version} is not published yet`);
-      hasUnpublished = true;
-    }
+  if (isPublished) {
+    console.log(`${pkg.name}@${pkg.version} is already published`);
+  } else {
+    console.log(`${pkg.name}@${pkg.version} is not published yet`);
   }
 
+  const shouldPublish = !isPublished;
   const output = [
-    `has_unpublished=${String(hasUnpublished)}`,
-    `should_publish=${String(hasUnpublished)}`,
+    `has_unpublished=${String(shouldPublish)}`,
+    `should_publish=${String(shouldPublish)}`,
   ].join("\n") + "\n";
 
   if (process.env.GITHUB_OUTPUT) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,21 +45,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check whether this version still needs publishing
+      - name: Check for unpublished package versions
         if: steps.changesets.outputs.hasChangesets == 'false'
         id: publish-check
-        shell: bash
-        run: |
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-
-          echo "Checking whether ${PACKAGE_NAME}@${PACKAGE_VERSION} is already on npm"
-          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+        run: node .github/scripts/has-unpublished-packages.mjs
 
   publish:
     name: Publish


### PR DESCRIPTION
## Summary
- add Changesets-based release PR creation and npm publishing
- split publishing into a separate OIDC-enabled job
- use `.github/scripts/has-unpublished-packages.mjs` to skip publishing when the current package version is already on npm

## Testing
- [x] `GITHUB_OUTPUT=/tmp/publish-check-output node .github/scripts/has-unpublished-packages.mjs`