### PR TITLE
chore: add missing changeset for post-2.10.5 fixes

### DIFF
--- a/.changeset/post-2-10-5-fixes.md
+++ b/.changeset/post-2-10-5-fixes.md
@@ -1,0 +1,6 @@
+---
+'@preact/preset-vite': patch
+---
+- prevent the CJS build from rewriting the hook names helper import to `require()`
+- skip devtools plugin resolve/transform hooks unless devtools support is enabled
+- add the `vite-plugin` keyword for registry discovery


### PR DESCRIPTION
- add the missing post-2.10.5 changeset for the unreleased patch-worthy changes
- cover the CJS hook import fix, devtools hook skip, and `vite-plugin` keyword addition
