### PR TITLE
ci: harden trusted publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
 
@@ -70,6 +71,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
+          package-manager-cache: false
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version-file: package.json
@@ -64,12 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           package-manager-cache: false
           node-version: 22


### PR DESCRIPTION
## Summary
- Explicitly disables setup-node package-manager auto-caching in the trusted publishing workflow.
- Removes existing publish-workflow dependency cache usage where present.
- Pins external GitHub Actions in the trusted publish workflow to full commit SHAs, keeping the original tag as a comment breadcrumb.

## Why
Trusted publishing/OIDC workflows should not restore shared dependency caches, and tag-based action references can be retargeted after compromise. The StepSecurity advisory for `actions-cool/issues-helper` is the concrete failure mode: tags were moved to an imposter commit, while full-SHA pinned workflows were unaffected.

## Verification
- Parsed the edited workflow YAML locally with PyYAML.
- Re-scanned release workflows for `actions/setup-node` without `package-manager-cache: false` and for `actions/cache` usage.
- Re-scanned trusted publish workflow `uses:` entries and confirmed all external actions are pinned to 40-character commit SHAs.
