### PR TITLE
fix: kickstart changesets bot

### DIFF
--- a/.changeset/post-2-10-5-fixes.md
+++ b/.changeset/post-2-10-5-fixes.md
@@ -1,6 +1,7 @@
 ---
 '@preact/preset-vite': patch
 ---
+
 - prevent the CJS build from rewriting the hook names helper import to `require()`
 - skip devtools plugin resolve/transform hooks unless devtools support is enabled
 - add the `vite-plugin` keyword for registry discovery


### PR DESCRIPTION
Changesets bot wasn't added to the repo, but now that it is, I think we need to merge in a change to get it going? Dunno